### PR TITLE
#29 -  Refactor mapping functions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -41,5 +41,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>$(AssemblyName).IntegrationTests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/ZCrew.StateCraft/Mapping/Contracts/IMappingFunction.cs
+++ b/src/ZCrew.StateCraft/Mapping/Contracts/IMappingFunction.cs
@@ -1,0 +1,21 @@
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.Mapping.Contracts;
+
+/// <summary>
+///     Defines a function that maps parameters from the previous state to parameters for the next state during a
+///     transition.
+/// </summary>
+internal interface IMappingFunction
+{
+    /// <summary>
+    ///     Executes the mapping function by retrieving input parameters from the previous state, transforming them
+    ///     through the configured mapping function, and setting the output parameters for the next state.
+    /// </summary>
+    /// <param name="parameter">
+    ///     The state machine parameters container used to read previous and write next parameters.
+    /// </param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous mapping operation.</returns>
+    Task Map(IStateMachineParameters parameter, CancellationToken token);
+}

--- a/src/ZCrew.StateCraft/Mapping/MappingFunction.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunction.cs
@@ -1,0 +1,87 @@
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping.Contracts;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.Mapping;
+
+/// <inheritdoc />
+internal class MappingFunction<TIn, TOut> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn, TOut> function;
+
+    public MappingFunction(IAsyncFunc<TIn, TOut> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var output = await this.function.InvokeAsync(parameter, token);
+        parameters.SetNextParameters([output]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunction<TIn1, TIn2, TOut> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TOut> function;
+
+    public MappingFunction(IAsyncFunc<TIn1, TIn2, TOut> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, token);
+        parameters.SetNextParameters([output]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunction<TIn1, TIn2, TIn3, TOut> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, TOut> function;
+
+    public MappingFunction(IAsyncFunc<TIn1, TIn2, TIn3, TOut> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
+        parameters.SetNextParameters([output]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunction<TIn1, TIn2, TIn3, TIn4, TOut> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, TIn4, TOut> function;
+
+    public MappingFunction(IAsyncFunc<TIn1, TIn2, TIn3, TIn4, TOut> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
+        parameters.SetNextParameters([output]);
+    }
+}

--- a/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple2.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple2.cs
@@ -1,0 +1,87 @@
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping.Contracts;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.Mapping;
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple2<TIn, TOut1, TOut2> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn, (TOut1, TOut2)> function;
+
+    public MappingFunctionValueTuple2(IAsyncFunc<TIn, (TOut1, TOut2)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var output = await this.function.InvokeAsync(parameter, token);
+        parameters.SetNextParameters([output.Item1, output.Item2]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple2<TIn1, TIn2, TOut1, TOut2> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, (TOut1, TOut2)> function;
+
+    public MappingFunctionValueTuple2(IAsyncFunc<TIn1, TIn2, (TOut1, TOut2)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, token);
+        parameters.SetNextParameters([output.Item1, output.Item2]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple2<TIn1, TIn2, TIn3, TOut1, TOut2> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, (TOut1, TOut2)> function;
+
+    public MappingFunctionValueTuple2(IAsyncFunc<TIn1, TIn2, TIn3, (TOut1, TOut2)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
+        parameters.SetNextParameters([output.Item1, output.Item2]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple2<TIn1, TIn2, TIn3, TIn4, TOut1, TOut2> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, TIn4, (TOut1, TOut2)> function;
+
+    public MappingFunctionValueTuple2(IAsyncFunc<TIn1, TIn2, TIn3, TIn4, (TOut1, TOut2)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
+        parameters.SetNextParameters([output.Item1, output.Item2]);
+    }
+}

--- a/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple3.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple3.cs
@@ -1,0 +1,87 @@
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping.Contracts;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.Mapping;
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple3<TIn, TOut1, TOut2, TOut3> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn, (TOut1, TOut2, TOut3)> function;
+
+    public MappingFunctionValueTuple3(IAsyncFunc<TIn, (TOut1, TOut2, TOut3)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var output = await this.function.InvokeAsync(parameter, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple3<TIn1, TIn2, TOut1, TOut2, TOut3> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, (TOut1, TOut2, TOut3)> function;
+
+    public MappingFunctionValueTuple3(IAsyncFunc<TIn1, TIn2, (TOut1, TOut2, TOut3)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple3<TIn1, TIn2, TIn3, TOut1, TOut2, TOut3> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, (TOut1, TOut2, TOut3)> function;
+
+    public MappingFunctionValueTuple3(IAsyncFunc<TIn1, TIn2, TIn3, (TOut1, TOut2, TOut3)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple3<TIn1, TIn2, TIn3, TIn4, TOut1, TOut2, TOut3> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, TIn4, (TOut1, TOut2, TOut3)> function;
+
+    public MappingFunctionValueTuple3(IAsyncFunc<TIn1, TIn2, TIn3, TIn4, (TOut1, TOut2, TOut3)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+    }
+}

--- a/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple4.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple4.cs
@@ -1,0 +1,87 @@
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping.Contracts;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.Mapping;
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple4<TIn, TOut1, TOut2, TOut3, TOut4> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn, (TOut1, TOut2, TOut3, TOut4)> function;
+
+    public MappingFunctionValueTuple4(IAsyncFunc<TIn, (TOut1, TOut2, TOut3, TOut4)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var output = await this.function.InvokeAsync(parameter, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple4<TIn1, TIn2, TOut1, TOut2, TOut3, TOut4> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, (TOut1, TOut2, TOut3, TOut4)> function;
+
+    public MappingFunctionValueTuple4(IAsyncFunc<TIn1, TIn2, (TOut1, TOut2, TOut3, TOut4)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple4<TIn1, TIn2, TIn3, TOut1, TOut2, TOut3, TOut4> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, (TOut1, TOut2, TOut3, TOut4)> function;
+
+    public MappingFunctionValueTuple4(IAsyncFunc<TIn1, TIn2, TIn3, (TOut1, TOut2, TOut3, TOut4)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+    }
+}
+
+/// <inheritdoc />
+internal class MappingFunctionValueTuple4<TIn1, TIn2, TIn3, TIn4, TOut1, TOut2, TOut3, TOut4> : IMappingFunction
+{
+    private readonly IAsyncFunc<TIn1, TIn2, TIn3, TIn4, (TOut1, TOut2, TOut3, TOut4)> function;
+
+    public MappingFunctionValueTuple4(IAsyncFunc<TIn1, TIn2, TIn3, TIn4, (TOut1, TOut2, TOut3, TOut4)> function)
+    {
+        this.function = function;
+    }
+
+    /// <inheritdoc />
+    public async Task Map(IStateMachineParameters parameters, CancellationToken token)
+    {
+        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
+        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
+        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionTests.cs
@@ -1,0 +1,304 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.UnitTests.Mapping;
+
+public class MappingFunctionTests
+{
+    [Fact]
+    public async Task Map_TIn_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, string>>();
+        function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns("result");
+
+        var mapper = new MappingFunction<int, string>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result" })));
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut_WhenCalled_ShouldPassParameterFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, string>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns("result");
+
+        var mapper = new MappingFunction<int, string>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, string>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunction<int, string>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+
+        var function = Substitute.For<IAsyncFunc<int, string>>();
+        function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns("first");
+        function.InvokeAsync(2, Arg.Any<CancellationToken>()).Returns("second");
+
+        var mapper = new MappingFunction<int, string>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first" })));
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second" })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, double>>();
+        function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns(3.14);
+
+        var mapper = new MappingFunction<int, string, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut_WhenCalled_ShouldPassParametersFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, double>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(3.14);
+
+        var mapper = new MappingFunction<int, string, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(1, "input", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, double>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunction<int, string, double>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, double>>();
+        function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns(3.14);
+
+        var mapper = new MappingFunction<int, string, bool, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenCalled_ShouldPassParametersFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, double>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(3.14);
+
+        var mapper = new MappingFunction<int, string, bool, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(1, "input", true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, double>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunction<int, string, bool, double>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('x');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, double>>();
+        function.InvokeAsync(1, "input", true, 'x', Arg.Any<CancellationToken>()).Returns(3.14);
+
+        var mapper = new MappingFunction<int, string, bool, char, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenCalled_ShouldPassParametersFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('x');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, double>>();
+        function
+            .InvokeAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<char>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(3.14);
+
+        var mapper = new MappingFunction<int, string, bool, char, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(1, "input", true, 'x', Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('x');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, double>>();
+        function
+            .InvokeAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<char>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunction<int, string, bool, char, double>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple2Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple2Tests.cs
@@ -1,0 +1,314 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.UnitTests.Mapping;
+
+public class MappingFunctionValueTuple2Tests
+{
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
+        function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns(("result", 3.14));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result", 3.14 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_WhenCalled_ShouldPassParameterFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(("result", 3.14));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
+        function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns(("first", 1.0));
+        function.InvokeAsync(2, Arg.Any<CancellationToken>()).Returns(("second", 2.0));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first", 1.0 })));
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second", 2.0 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool)>>();
+        function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns((3.14, true));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double, bool>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, true })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenCalled_ShouldPassParametersFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((3.14, true));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double, bool>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(1, "input", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple2<int, string, double, bool>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char)>>();
+        function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns((3.14, 'x'));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, bool, double, char>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 'x' })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenCalled_ShouldPassParametersFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((3.14, 'x'));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, bool, double, char>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(1, "input", true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple2<int, string, bool, double, char>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long)>>();
+        function.InvokeAsync(1, "input", true, 'y', Arg.Any<CancellationToken>()).Returns((3.14, 100L));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, bool, char, double, long>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 100L })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenCalled_ShouldPassParametersFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long)>>();
+        function
+            .InvokeAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<char>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns((3.14, 100L));
+
+        var mapper = new MappingFunctionValueTuple2<int, string, bool, char, double, long>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(1, "input", true, 'y', Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long)>>();
+        function
+            .InvokeAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<char>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple2<int, string, bool, char, double, long>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple3Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple3Tests.cs
@@ -1,0 +1,243 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.UnitTests.Mapping;
+
+public class MappingFunctionValueTuple3Tests
+{
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
+        function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns(("result", 3.14, true));
+
+        var mapper = new MappingFunctionValueTuple3<int, string, double, bool>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result", 3.14, true })));
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalled_ShouldPassParameterFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(("result", 3.14, true));
+
+        var mapper = new MappingFunctionValueTuple3<int, string, double, bool>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple3<int, string, double, bool>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
+        function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns(("first", 1.0, true));
+        function.InvokeAsync(2, Arg.Any<CancellationToken>()).Returns(("second", 2.0, false));
+
+        var mapper = new MappingFunctionValueTuple3<int, string, double, bool>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first", 1.0, true })));
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second", 2.0, false })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char)>>();
+        function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns((3.14, true, 'x'));
+
+        var mapper = new MappingFunctionValueTuple3<int, string, double, bool, char>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, true, 'x' })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple3<int, string, double, bool, char>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long)>>();
+        function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns((3.14, 'x', 100L));
+
+        var mapper = new MappingFunctionValueTuple3<int, string, bool, double, char, long>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 'x', 100L })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple3<int, string, bool, double, char, long>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short)>>();
+        function.InvokeAsync(1, "input", true, 'y', Arg.Any<CancellationToken>()).Returns((3.14, 100L, (short)50));
+
+        var mapper = new MappingFunctionValueTuple3<int, string, bool, char, double, long, short>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 100L, (short)50 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short)>>();
+        function
+            .InvokeAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<char>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple3<int, string, bool, char, double, long, short>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple4Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple4Tests.cs
@@ -1,0 +1,247 @@
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Mapping;
+using ZCrew.StateCraft.Parameters.Contracts;
+
+namespace ZCrew.StateCraft.UnitTests.Mapping;
+
+public class MappingFunctionValueTuple4Tests
+{
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
+        function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns(("result", 3.14, true, 'x'));
+
+        var mapper = new MappingFunctionValueTuple4<int, string, double, bool, char>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result", 3.14, true, 'x' })));
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldPassParameterFromStateMachineParametersToFunction()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(("result", 3.14, true, 'x'));
+
+        var mapper = new MappingFunctionValueTuple4<int, string, double, bool, char>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await function.Received(1).InvokeAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(42);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
+        function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple4<int, string, double, bool, char>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+
+        var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
+        function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns(("first", 1.0, true, 'a'));
+        function.InvokeAsync(2, Arg.Any<CancellationToken>()).Returns(("second", 2.0, false, 'b'));
+
+        var mapper = new MappingFunctionValueTuple4<int, string, double, bool, char>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first", 1.0, true, 'a' })));
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second", 2.0, false, 'b' })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char, long)>>();
+        function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns((3.14, true, 'x', 100L));
+
+        var mapper = new MappingFunctionValueTuple4<int, string, double, bool, char, long>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, true, 'x', 100L })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+
+        var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char, long)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple4<int, string, double, bool, char, long>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long, short)>>();
+        function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns((3.14, 'x', 100L, (short)50));
+
+        var mapper = new MappingFunctionValueTuple4<int, string, bool, double, char, long, short>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 'x', 100L, (short)50 })));
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long, short)>>();
+        function
+            .InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple4<int, string, bool, double, char, long, short>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short, byte)>>();
+        function
+            .InvokeAsync(1, "input", true, 'y', Arg.Any<CancellationToken>())
+            .Returns((3.14, 100L, (short)50, (byte)25));
+
+        var mapper = new MappingFunctionValueTuple4<int, string, bool, char, double, long, short, byte>(function);
+
+        // Act
+        await mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        parameters
+            .Received(1)
+            .SetNextParameters(
+                Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 100L, (short)50, (byte)25 }))
+            );
+    }
+
+    [Fact]
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    {
+        // Arrange
+        var parameters = Substitute.For<IStateMachineParameters>();
+        parameters.GetPreviousParameter<int>(0).Returns(1);
+        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameter<char>(3).Returns('y');
+
+        var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short, byte)>>();
+        function
+            .InvokeAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<char>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new InvalidOperationException());
+
+        var mapper = new MappingFunctionValueTuple4<int, string, bool, char, double, long, short, byte>(function);
+
+        // Act
+        var act = () => mapper.Map(parameters, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/ZCrew.StateCraft.UnitTests.csproj
+++ b/tests/ZCrew.StateCraft.UnitTests/ZCrew.StateCraft.UnitTests.csproj
@@ -1,1 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Folder Include="Mapping\" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Refactored mapping functions to allow up to 4 inputs and up to 4 outputs. This is currently not used but will be soon.

Closes #29