### PR TITLE
#42 - Redesign IStateMachineParameters to use n-arity methods

### DIFF
--- a/src/ZCrew.StateCraft/Mapping/MappingFunction.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunction.cs
@@ -17,9 +17,9 @@ internal class MappingFunction<TIn, TOut> : IMappingFunction
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var parameter = parameters.GetPreviousParameter<TIn>();
         var output = await this.function.InvokeAsync(parameter, token);
-        parameters.SetNextParameters([output]);
+        parameters.SetNextParameter(output);
     }
 }
 
@@ -36,10 +36,9 @@ internal class MappingFunction<TIn1, TIn2, TOut> : IMappingFunction
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var (parameter1, parameter2) = parameters.GetPreviousParameters<TIn1, TIn2>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, token);
-        parameters.SetNextParameters([output]);
+        parameters.SetNextParameter(output);
     }
 }
 
@@ -56,11 +55,9 @@ internal class MappingFunction<TIn1, TIn2, TIn3, TOut> : IMappingFunction
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var (parameter1, parameter2, parameter3) = parameters.GetPreviousParameters<TIn1, TIn2, TIn3>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
-        parameters.SetNextParameters([output]);
+        parameters.SetNextParameter(output);
     }
 }
 
@@ -77,11 +74,13 @@ internal class MappingFunction<TIn1, TIn2, TIn3, TIn4, TOut> : IMappingFunction
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
-        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var (parameter1, parameter2, parameter3, parameter4) = parameters.GetPreviousParameters<
+            TIn1,
+            TIn2,
+            TIn3,
+            TIn4
+        >();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
-        parameters.SetNextParameters([output]);
+        parameters.SetNextParameter(output);
     }
 }

--- a/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple2.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple2.cs
@@ -17,9 +17,9 @@ internal class MappingFunctionValueTuple2<TIn, TOut1, TOut2> : IMappingFunction
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var parameter = parameters.GetPreviousParameter<TIn>();
         var output = await this.function.InvokeAsync(parameter, token);
-        parameters.SetNextParameters([output.Item1, output.Item2]);
+        parameters.SetNextParameters<TOut1, TOut2>(output.Item1, output.Item2);
     }
 }
 
@@ -36,10 +36,9 @@ internal class MappingFunctionValueTuple2<TIn1, TIn2, TOut1, TOut2> : IMappingFu
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var (parameter1, parameter2) = parameters.GetPreviousParameters<TIn1, TIn2>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, token);
-        parameters.SetNextParameters([output.Item1, output.Item2]);
+        parameters.SetNextParameters<TOut1, TOut2>(output.Item1, output.Item2);
     }
 }
 
@@ -56,11 +55,9 @@ internal class MappingFunctionValueTuple2<TIn1, TIn2, TIn3, TOut1, TOut2> : IMap
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var (parameter1, parameter2, parameter3) = parameters.GetPreviousParameters<TIn1, TIn2, TIn3>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
-        parameters.SetNextParameters([output.Item1, output.Item2]);
+        parameters.SetNextParameters<TOut1, TOut2>(output.Item1, output.Item2);
     }
 }
 
@@ -77,11 +74,13 @@ internal class MappingFunctionValueTuple2<TIn1, TIn2, TIn3, TIn4, TOut1, TOut2> 
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
-        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var (parameter1, parameter2, parameter3, parameter4) = parameters.GetPreviousParameters<
+            TIn1,
+            TIn2,
+            TIn3,
+            TIn4
+        >();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
-        parameters.SetNextParameters([output.Item1, output.Item2]);
+        parameters.SetNextParameters<TOut1, TOut2>(output.Item1, output.Item2);
     }
 }

--- a/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple3.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple3.cs
@@ -17,9 +17,9 @@ internal class MappingFunctionValueTuple3<TIn, TOut1, TOut2, TOut3> : IMappingFu
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var parameter = parameters.GetPreviousParameter<TIn>();
         var output = await this.function.InvokeAsync(parameter, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+        parameters.SetNextParameters(output.Item1, output.Item2, output.Item3);
     }
 }
 
@@ -36,10 +36,9 @@ internal class MappingFunctionValueTuple3<TIn1, TIn2, TOut1, TOut2, TOut3> : IMa
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var (parameter1, parameter2) = parameters.GetPreviousParameters<TIn1, TIn2>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+        parameters.SetNextParameters(output.Item1, output.Item2, output.Item3);
     }
 }
 
@@ -56,11 +55,9 @@ internal class MappingFunctionValueTuple3<TIn1, TIn2, TIn3, TOut1, TOut2, TOut3>
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var (parameter1, parameter2, parameter3) = parameters.GetPreviousParameters<TIn1, TIn2, TIn3>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+        parameters.SetNextParameters(output.Item1, output.Item2, output.Item3);
     }
 }
 
@@ -77,11 +74,13 @@ internal class MappingFunctionValueTuple3<TIn1, TIn2, TIn3, TIn4, TOut1, TOut2, 
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
-        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var (parameter1, parameter2, parameter3, parameter4) = parameters.GetPreviousParameters<
+            TIn1,
+            TIn2,
+            TIn3,
+            TIn4
+        >();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3]);
+        parameters.SetNextParameters(output.Item1, output.Item2, output.Item3);
     }
 }

--- a/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple4.cs
+++ b/src/ZCrew.StateCraft/Mapping/MappingFunctionValueTuple4.cs
@@ -17,9 +17,14 @@ internal class MappingFunctionValueTuple4<TIn, TOut1, TOut2, TOut3, TOut4> : IMa
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter = parameters.GetPreviousParameter<TIn>(0);
+        var parameter = parameters.GetPreviousParameter<TIn>();
         var output = await this.function.InvokeAsync(parameter, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+        parameters.SetNextParameters<TOut1, TOut2, TOut3, TOut4>(
+            output.Item1,
+            output.Item2,
+            output.Item3,
+            output.Item4
+        );
     }
 }
 
@@ -36,10 +41,14 @@ internal class MappingFunctionValueTuple4<TIn1, TIn2, TOut1, TOut2, TOut3, TOut4
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
+        var (parameter1, parameter2) = parameters.GetPreviousParameters<TIn1, TIn2>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+        parameters.SetNextParameters<TOut1, TOut2, TOut3, TOut4>(
+            output.Item1,
+            output.Item2,
+            output.Item3,
+            output.Item4
+        );
     }
 }
 
@@ -56,11 +65,14 @@ internal class MappingFunctionValueTuple4<TIn1, TIn2, TIn3, TOut1, TOut2, TOut3,
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
+        var (parameter1, parameter2, parameter3) = parameters.GetPreviousParameters<TIn1, TIn2, TIn3>();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+        parameters.SetNextParameters<TOut1, TOut2, TOut3, TOut4>(
+            output.Item1,
+            output.Item2,
+            output.Item3,
+            output.Item4
+        );
     }
 }
 
@@ -77,11 +89,18 @@ internal class MappingFunctionValueTuple4<TIn1, TIn2, TIn3, TIn4, TOut1, TOut2, 
     /// <inheritdoc />
     public async Task Map(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter1 = parameters.GetPreviousParameter<TIn1>(0);
-        var parameter2 = parameters.GetPreviousParameter<TIn2>(1);
-        var parameter3 = parameters.GetPreviousParameter<TIn3>(2);
-        var parameter4 = parameters.GetPreviousParameter<TIn4>(3);
+        var (parameter1, parameter2, parameter3, parameter4) = parameters.GetPreviousParameters<
+            TIn1,
+            TIn2,
+            TIn3,
+            TIn4
+        >();
         var output = await this.function.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
-        parameters.SetNextParameters([output.Item1, output.Item2, output.Item3, output.Item4]);
+        parameters.SetNextParameters<TOut1, TOut2, TOut3, TOut4>(
+            output.Item1,
+            output.Item2,
+            output.Item3,
+            output.Item4
+        );
     }
 }

--- a/src/ZCrew.StateCraft/Parameters/Contracts/IStateMachineParameters.cs
+++ b/src/ZCrew.StateCraft/Parameters/Contracts/IStateMachineParameters.cs
@@ -12,7 +12,7 @@ namespace ZCrew.StateCraft.Parameters.Contracts;
 ///     A typical transition follows this sequence:
 ///     <list type="number">
 ///         <item><see cref="BeginTransition"/> - Captures the current state for potential rollback</item>
-///         <item><see cref="SetNextParameters"/> - Stages the parameters for the target state</item>
+///         <item><see cref="SetNextParameter{T}(T)"/> - Stages the parameters for the target state</item>
 ///         <item><see cref="CommitTransition"/> - Finalizes the transition, promoting next to current</item>
 ///     </list>
 /// </para>
@@ -25,11 +25,49 @@ internal interface IStateMachineParameters
     StateMachineParametersFlags Status { get; }
 
     /// <summary>
+    ///     The previous type parameters, if set.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status.
+    /// </exception>
+    IReadOnlyList<Type> PreviousParameterTypes { get; }
+
+    /// <summary>
+    ///     The current type parameters, if set.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status.
+    /// </exception>
+    IReadOnlyList<Type> CurrentParameterTypes { get; }
+
+    /// <summary>
+    ///     The next type parameters, if set.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status.
+    /// </exception>
+    IReadOnlyList<Type> NextParameterTypes { get; }
+
+    /// <summary>
     ///     Retrieves a parameter from the previous state.
     /// </summary>
     /// <typeparam name="T">The expected type of the parameter.</typeparam>
     /// <param name="index">The zero-based index of the parameter.</param>
     /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     If <paramref name="index"/> is negative or exceeds the parameter count.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If the parameter cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    [Obsolete($"Use {nameof(GetPreviousParameter)}<T>() instead")]
     T GetPreviousParameter<T>(int index);
 
     /// <summary>
@@ -38,6 +76,17 @@ internal interface IStateMachineParameters
     /// <typeparam name="T">The expected type of the parameter.</typeparam>
     /// <param name="index">The zero-based index of the parameter.</param>
     /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     If <paramref name="index"/> is negative or exceeds the parameter count.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If the parameter cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    [Obsolete($"Use {nameof(GetCurrentParameter)}<T>() instead")]
     T GetCurrentParameter<T>(int index);
 
     /// <summary>
@@ -46,6 +95,17 @@ internal interface IStateMachineParameters
     /// <typeparam name="T">The expected type of the parameter.</typeparam>
     /// <param name="index">The zero-based index of the parameter.</param>
     /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     If <paramref name="index"/> is negative or exceeds the parameter count.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If the parameter cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    [Obsolete($"Use {nameof(GetNextParameter)}<T>() instead")]
     T GetNextParameter<T>(int index);
 
     /// <summary>
@@ -54,24 +114,304 @@ internal interface IStateMachineParameters
     /// <param name="nextParameters">
     ///     The parameters to stage. These become current upon <see cref="CommitTransition"/>.
     /// </param>
+    [Obsolete($"Use {nameof(SetNextParameter)} instead")]
     void SetNextParameters(object?[] nextParameters);
+
+    /// <summary>
+    ///     Stages a parameter for the next state.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter.</typeparam>
+    /// <param name="index">The zero-based index of the parameter.</param>
+    /// <param name="nextParameter">
+    ///     The parameter to stage. This becomes current upon <see cref="CommitTransition"/>.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     If <paramref name="index"/> is negative or exceeds the maximum parameter count.
+    /// </exception>
+    [Obsolete($"Use {nameof(SetNextParameter)}<T>(T) instead")]
+    void SetNextParameter<T>(int index, T nextParameter);
+
+    #region Arity-specific setters
+
+    /// <summary>
+    ///     Stages empty parameters for a parameterless transition.
+    /// </summary>
+    void SetEmptyNextParameters();
+
+    /// <summary>
+    ///     Stages a single parameter for the next state.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter.</typeparam>
+    /// <param name="nextParameter">
+    ///     The parameter to stage. This becomes current upon <see cref="CommitTransition"/>.
+    /// </param>
+    void SetNextParameter<T>(T nextParameter);
+
+    /// <summary>
+    ///     Stages two parameters for the next state.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter.</typeparam>
+    /// <param name="parameter1">The first parameter to stage.</param>
+    /// <param name="parameter2">The second parameter to stage.</param>
+    void SetNextParameters<T1, T2>(T1 parameter1, T2 parameter2);
+
+    /// <summary>
+    ///     Stages three parameters for the next state.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter.</typeparam>
+    /// <param name="parameter1">The first parameter to stage.</param>
+    /// <param name="parameter2">The second parameter to stage.</param>
+    /// <param name="parameter3">The third parameter to stage.</param>
+    void SetNextParameters<T1, T2, T3>(T1 parameter1, T2 parameter2, T3 parameter3);
+
+    /// <summary>
+    ///     Stages four parameters for the next state.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
+    /// <param name="parameter1">The first parameter to stage.</param>
+    /// <param name="parameter2">The second parameter to stage.</param>
+    /// <param name="parameter3">The third parameter to stage.</param>
+    /// <param name="parameter4">The fourth parameter to stage.</param>
+    void SetNextParameters<T1, T2, T3, T4>(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4);
+
+    #endregion
+
+    #region Arity-specific getters — Previous
+
+    /// <summary>
+    ///     Retrieves a single parameter from the previous state.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the parameter.</typeparam>
+    /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status, or if the
+    ///     parameter count is less than 1.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If the parameter cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    T GetPreviousParameter<T>();
+
+    /// <summary>
+    ///     Retrieves two parameters from the previous state.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status, or if the
+    ///     parameter count is less than 2.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2) GetPreviousParameters<T1, T2>();
+
+    /// <summary>
+    ///     Retrieves three parameters from the previous state.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The expected type of the third parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status, or if the
+    ///     parameter count is less than 3.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2, T3) GetPreviousParameters<T1, T2, T3>();
+
+    /// <summary>
+    ///     Retrieves four parameters from the previous state.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The expected type of the third parameter.</typeparam>
+    /// <typeparam name="T4">The expected type of the fourth parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status, or if the
+    ///     parameter count is less than 4.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2, T3, T4) GetPreviousParameters<T1, T2, T3, T4>();
+
+    #endregion
+
+    #region Arity-specific getters — Current
+
+    /// <summary>
+    ///     Retrieves a single parameter from the current state.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the parameter.</typeparam>
+    /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status, or if the
+    ///     parameter count is less than 1.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If the parameter cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    T GetCurrentParameter<T>();
+
+    /// <summary>
+    ///     Retrieves two parameters from the current state.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status, or if the
+    ///     parameter count is less than 2.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2) GetCurrentParameters<T1, T2>();
+
+    /// <summary>
+    ///     Retrieves three parameters from the current state.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The expected type of the third parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status, or if the
+    ///     parameter count is less than 3.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2, T3) GetCurrentParameters<T1, T2, T3>();
+
+    /// <summary>
+    ///     Retrieves four parameters from the current state.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The expected type of the third parameter.</typeparam>
+    /// <typeparam name="T4">The expected type of the fourth parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status, or if the
+    ///     parameter count is less than 4.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2, T3, T4) GetCurrentParameters<T1, T2, T3, T4>();
+
+    #endregion
+
+    #region Arity-specific getters — Next
+
+    /// <summary>
+    ///     Retrieves a single staged parameter that will become current upon commit.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the parameter.</typeparam>
+    /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status, or if the
+    ///     parameter count is less than 1.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If the parameter cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    T GetNextParameter<T>();
+
+    /// <summary>
+    ///     Retrieves two staged parameters that will become current upon commit.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status, or if the
+    ///     parameter count is less than 2.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2) GetNextParameters<T1, T2>();
+
+    /// <summary>
+    ///     Retrieves three staged parameters that will become current upon commit.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The expected type of the third parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status, or if the
+    ///     parameter count is less than 3.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2, T3) GetNextParameters<T1, T2, T3>();
+
+    /// <summary>
+    ///     Retrieves four staged parameters that will become current upon commit.
+    /// </summary>
+    /// <typeparam name="T1">The expected type of the first parameter.</typeparam>
+    /// <typeparam name="T2">The expected type of the second parameter.</typeparam>
+    /// <typeparam name="T3">The expected type of the third parameter.</typeparam>
+    /// <typeparam name="T4">The expected type of the fourth parameter.</typeparam>
+    /// <returns>A tuple of the parameter values.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     If the <see cref="Status"/> does not indicate the
+    ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status, or if the
+    ///     parameter count is less than 4.
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    ///     If any parameter cannot be cast to its expected type.
+    /// </exception>
+    (T1, T2, T3, T4) GetNextParameters<T1, T2, T3, T4>();
+
+    #endregion
 
     /// <summary>
     ///     Begins a transition by capturing the current parameters for potential rollback.
     /// </summary>
     /// <remarks>
-    ///     Must be called before <see cref="SetNextParameters"/> and <see cref="CommitTransition"/>.
-    ///     If an error occurs after this call, use <see cref="RollbackTransition"/> to restore the previous state.
+    ///     Must be called before <see cref="SetNextParameter{T}(T)"/> and
+    ///     <see cref="CommitTransition"/>.
+    ///     If an error occurs after this call, use <see cref="RollbackTransition"/> to
+    ///     restore the previous state.
     /// </remarks>
     void BeginTransition();
 
     /// <summary>
-    ///     Reverts a transition in progress, restoring the state captured by <see cref="BeginTransition"/>.
+    ///     Reverts a transition in progress, restoring the state captured by
+    ///     <see cref="BeginTransition"/>.
     /// </summary>
     void RollbackTransition();
 
     /// <summary>
-    ///     Completes the transition, promoting staged parameters to current and current to previous.
+    ///     Completes the transition, promoting staged parameters to current and current
+    ///     to previous.
     /// </summary>
     void CommitTransition();
 

--- a/src/ZCrew.StateCraft/Parameters/Contracts/StateMachineParametersFlags.cs
+++ b/src/ZCrew.StateCraft/Parameters/Contracts/StateMachineParametersFlags.cs
@@ -26,7 +26,7 @@ internal enum StateMachineParametersFlags
 
     /// <summary>
     /// The next parameter slot has been set.
-    /// This flag is set by <see cref="IStateMachineParameters.SetNextParameters"/>.
+    /// This flag is set by <see cref="IStateMachineParameters.SetNextParameter{T}"/>.
     /// </summary>
     NextParametersSet = 1 << 2,
 }

--- a/src/ZCrew.StateCraft/StateMachines/StateMachine.cs
+++ b/src/ZCrew.StateCraft/StateMachines/StateMachine.cs
@@ -75,7 +75,9 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
     {
         get
         {
-            return Parameters.Status.HasFlag(StateMachineParametersFlags.CurrentParametersSet)
+            return
+                Parameters.Status.HasFlag(StateMachineParametersFlags.CurrentParametersSet)
+                && Parameters.CurrentParameterTypes.Count > 0
                 ? Parameters.GetCurrentParameter<object?>(0)
                 : null;
         }
@@ -87,7 +89,9 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
     {
         get
         {
-            return Parameters.Status.HasFlag(StateMachineParametersFlags.PreviousParametersSet)
+            return
+                Parameters.Status.HasFlag(StateMachineParametersFlags.PreviousParametersSet)
+                && Parameters.PreviousParameterTypes.Count > 0
                 ? Parameters.GetPreviousParameter<object?>(0)
                 : null;
         }
@@ -99,11 +103,23 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
     {
         get
         {
-            return Parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet)
+            return
+                Parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet)
+                && Parameters.NextParameterTypes.Count > 0
                 ? Parameters.GetNextParameter<object?>(0)
                 : null;
         }
-        set => Parameters.SetNextParameters([value]);
+        set
+        {
+            if (value == null)
+            {
+                Parameters.SetEmptyNextParameters();
+            }
+            else
+            {
+                Parameters.SetNextParameters([value]);
+            }
+        }
     }
 
     /// <inheritdoc />
@@ -345,7 +361,7 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         try
         {
             CurrentTransition = await CurrentState.GetTransition(transition, token);
-            Parameters.SetNextParameters([null]);
+            Parameters.SetEmptyNextParameters();
             NextState = CurrentTransition.Next.State;
             await ExitState(token);
             await Transition(token);
@@ -373,7 +389,7 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         try
         {
             CurrentTransition = await CurrentState.GetTransition(transition, parameter, token);
-            Parameters.SetNextParameters([parameter]);
+            Parameters.SetNextParameter(parameter);
             NextState = CurrentTransition.Next.State;
             await ExitState(token);
             await Transition(token);
@@ -436,7 +452,7 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
 
         try
         {
-            Parameters.SetNextParameters([null]);
+            Parameters.SetEmptyNextParameters();
             NextState = CurrentTransition.Next.State;
             await ExitState(token);
             await Transition(token);
@@ -470,7 +486,7 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
 
         try
         {
-            Parameters.SetNextParameters([parameter]);
+            Parameters.SetNextParameter(parameter);
             NextState = CurrentTransition.Next.State;
             await ExitState(token);
             await Transition(token);

--- a/src/ZCrew.StateCraft/States/NextState.cs
+++ b/src/ZCrew.StateCraft/States/NextState.cs
@@ -92,7 +92,7 @@ internal class NextState<TState, TTransition, T> : INextState<TState, TTransitio
     /// <inheritdoc />
     public async Task<bool> EvaluateConditions(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter = parameters.GetNextParameter<T>(0);
+        var parameter = parameters.GetNextParameter<T>();
         foreach (var condition in this.conditions)
         {
             var result = await condition.InvokeAsync(parameter, token);

--- a/src/ZCrew.StateCraft/States/ParameterizedState.cs
+++ b/src/ZCrew.StateCraft/States/ParameterizedState.cs
@@ -108,7 +108,7 @@ internal class ParameterizedState<TState, TTransition, T> : IState<TState, TTran
         CancellationToken token
     )
     {
-        var parameter = parameters.GetNextParameter<T>(0);
+        var parameter = parameters.GetNextParameter<T>();
         foreach (var handler in this.onStateChangeHandlers)
         {
             await StateMachine.RunWithExceptionHandling(

--- a/src/ZCrew.StateCraft/States/PreviousState.cs
+++ b/src/ZCrew.StateCraft/States/PreviousState.cs
@@ -92,7 +92,7 @@ internal class PreviousState<TState, TTransition, T> : IPreviousState<TState, TT
     /// <inheritdoc />
     public async Task<bool> EvaluateConditions(IStateMachineParameters parameters, CancellationToken token)
     {
-        var parameter = parameters.GetPreviousParameter<T>(0);
+        var parameter = parameters.GetPreviousParameter<T>();
         foreach (var condition in this.conditions)
         {
             var result = await condition.InvokeAsync(parameter, token);

--- a/src/ZCrew.StateCraft/TransitionTable.cs
+++ b/src/ZCrew.StateCraft/TransitionTable.cs
@@ -132,7 +132,7 @@ internal sealed class TransitionTable<TState, TTransition> : IEnumerable<ITransi
 
             // TODO MWZ: just pass in the correct state machine parameters this after the state machine is refactored
             var stateMachineParameters = new StateMachineParameters();
-            stateMachineParameters.SetNextParameters([previous]);
+            stateMachineParameters.SetNextParameter(previous);
             stateMachineParameters.CommitTransition();
             stateMachineParameters.BeginTransition();
             if (!await transition.EvaluateConditions(stateMachineParameters, token))
@@ -189,7 +189,7 @@ internal sealed class TransitionTable<TState, TTransition> : IEnumerable<ITransi
 
             // TODO MWZ: just pass in the correct state machine parameters this after the state machine is refactored
             var stateMachineParameters = new StateMachineParameters();
-            stateMachineParameters.SetNextParameters([next]);
+            stateMachineParameters.SetNextParameter(next);
             if (!await transition.EvaluateConditions(stateMachineParameters, token))
             {
                 continue;
@@ -252,10 +252,10 @@ internal sealed class TransitionTable<TState, TTransition> : IEnumerable<ITransi
 
             // TODO MWZ: just pass in the correct state machine parameters this after the state machine is refactored
             var stateMachineParameters = new StateMachineParameters();
-            stateMachineParameters.SetNextParameters([previous]);
+            stateMachineParameters.SetNextParameter(previous);
             stateMachineParameters.CommitTransition();
             stateMachineParameters.BeginTransition();
-            stateMachineParameters.SetNextParameters([next]);
+            stateMachineParameters.SetNextParameter(next);
             if (!await transition.EvaluateConditions(stateMachineParameters, token))
             {
                 continue;

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionTests.cs
@@ -9,11 +9,11 @@ namespace ZCrew.StateCraft.UnitTests.Mapping;
 public class MappingFunctionTests
 {
     [Fact]
-    public async Task Map_TIn_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn_TOut_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, string>>();
         function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns("result");
@@ -24,7 +24,7 @@ public class MappingFunctionTests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result" })));
+        parameters.Received(1).SetNextParameter("result");
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class MappingFunctionTests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, string>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns("result");
@@ -47,11 +47,11 @@ public class MappingFunctionTests
     }
 
     [Fact]
-    public async Task Map_TIn_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn_TOut_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, string>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
@@ -63,15 +63,15 @@ public class MappingFunctionTests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameter(Arg.Any<string>());
     }
 
     [Fact]
-    public async Task Map_TIn_TOut_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    public async Task Map_TIn_TOut_WhenCalledMultipleTimes_ShouldSetNextParameterEachTime()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+        parameters.GetPreviousParameter<int>().Returns(1, 2);
 
         var function = Substitute.For<IAsyncFunc<int, string>>();
         function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns("first");
@@ -84,17 +84,16 @@ public class MappingFunctionTests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first" })));
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second" })));
+        parameters.Received(1).SetNextParameter("first");
+        parameters.Received(1).SetNextParameter("second");
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TOut_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, double>>();
         function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns(3.14);
@@ -105,7 +104,7 @@ public class MappingFunctionTests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14 })));
+        parameters.Received(1).SetNextParameter(3.14);
     }
 
     [Fact]
@@ -113,8 +112,7 @@ public class MappingFunctionTests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, double>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(3.14);
@@ -129,12 +127,11 @@ public class MappingFunctionTests
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TOut_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, double>>();
         function
@@ -148,17 +145,15 @@ public class MappingFunctionTests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameter(Arg.Any<double>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, double>>();
         function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns(3.14);
@@ -169,7 +164,7 @@ public class MappingFunctionTests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14 })));
+        parameters.Received(1).SetNextParameter(3.14);
     }
 
     [Fact]
@@ -177,9 +172,7 @@ public class MappingFunctionTests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, double>>();
         function
@@ -196,13 +189,11 @@ public class MappingFunctionTests
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TOut_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, double>>();
         function
@@ -216,18 +207,15 @@ public class MappingFunctionTests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameter(Arg.Any<double>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('x');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'x'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, double>>();
         function.InvokeAsync(1, "input", true, 'x', Arg.Any<CancellationToken>()).Returns(3.14);
@@ -238,7 +226,7 @@ public class MappingFunctionTests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14 })));
+        parameters.Received(1).SetNextParameter(3.14);
     }
 
     [Fact]
@@ -246,10 +234,7 @@ public class MappingFunctionTests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('x');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'x'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, double>>();
         function
@@ -272,14 +257,11 @@ public class MappingFunctionTests
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('x');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'x'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, double>>();
         function
@@ -299,6 +281,6 @@ public class MappingFunctionTests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameter(Arg.Any<double>());
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple2Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple2Tests.cs
@@ -9,11 +9,11 @@ namespace ZCrew.StateCraft.UnitTests.Mapping;
 public class MappingFunctionValueTuple2Tests
 {
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn_TOut1_TOut2_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
         function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns(("result", 3.14));
@@ -24,9 +24,7 @@ public class MappingFunctionValueTuple2Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result", 3.14 })));
+        parameters.Received(1).SetNextParameters("result", 3.14);
     }
 
     [Fact]
@@ -34,7 +32,7 @@ public class MappingFunctionValueTuple2Tests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(("result", 3.14));
@@ -49,11 +47,11 @@ public class MappingFunctionValueTuple2Tests
     }
 
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
@@ -65,15 +63,15 @@ public class MappingFunctionValueTuple2Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<string>(), Arg.Any<double>());
     }
 
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    public async Task Map_TIn_TOut1_TOut2_WhenCalledMultipleTimes_ShouldSetNextParameterEachTime()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+        parameters.GetPreviousParameter<int>().Returns(1, 2);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double)>>();
         function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns(("first", 1.0));
@@ -86,21 +84,16 @@ public class MappingFunctionValueTuple2Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first", 1.0 })));
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second", 2.0 })));
+        parameters.Received(1).SetNextParameters("first", 1.0);
+        parameters.Received(1).SetNextParameters("second", 2.0);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool)>>();
         function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns((3.14, true));
@@ -111,9 +104,7 @@ public class MappingFunctionValueTuple2Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, true })));
+        parameters.Received(1).SetNextParameters(3.14, true);
     }
 
     [Fact]
@@ -121,8 +112,7 @@ public class MappingFunctionValueTuple2Tests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((3.14, true));
@@ -137,12 +127,11 @@ public class MappingFunctionValueTuple2Tests
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool)>>();
         function
@@ -156,17 +145,15 @@ public class MappingFunctionValueTuple2Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<double>(), Arg.Any<bool>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char)>>();
         function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns((3.14, 'x'));
@@ -177,7 +164,7 @@ public class MappingFunctionValueTuple2Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters.Received(1).SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 'x' })));
+        parameters.Received(1).SetNextParameters(3.14, 'x');
     }
 
     [Fact]
@@ -185,9 +172,7 @@ public class MappingFunctionValueTuple2Tests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char)>>();
         function
@@ -204,13 +189,11 @@ public class MappingFunctionValueTuple2Tests
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char)>>();
         function
@@ -224,18 +207,15 @@ public class MappingFunctionValueTuple2Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<double>(), Arg.Any<char>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long)>>();
         function.InvokeAsync(1, "input", true, 'y', Arg.Any<CancellationToken>()).Returns((3.14, 100L));
@@ -246,9 +226,7 @@ public class MappingFunctionValueTuple2Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 100L })));
+        parameters.Received(1).SetNextParameters(3.14, 100L);
     }
 
     [Fact]
@@ -256,10 +234,7 @@ public class MappingFunctionValueTuple2Tests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long)>>();
         function
@@ -282,14 +257,11 @@ public class MappingFunctionValueTuple2Tests
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long)>>();
         function
@@ -309,6 +281,6 @@ public class MappingFunctionValueTuple2Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<double>(), Arg.Any<long>());
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple3Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple3Tests.cs
@@ -9,11 +9,11 @@ namespace ZCrew.StateCraft.UnitTests.Mapping;
 public class MappingFunctionValueTuple3Tests
 {
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
         function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns(("result", 3.14, true));
@@ -24,9 +24,7 @@ public class MappingFunctionValueTuple3Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result", 3.14, true })));
+        parameters.Received(1).SetNextParameters("result", 3.14, true);
     }
 
     [Fact]
@@ -34,7 +32,7 @@ public class MappingFunctionValueTuple3Tests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(("result", 3.14, true));
@@ -49,11 +47,11 @@ public class MappingFunctionValueTuple3Tests
     }
 
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
@@ -65,15 +63,15 @@ public class MappingFunctionValueTuple3Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<string>(), Arg.Any<double>(), Arg.Any<bool>());
     }
 
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    public async Task Map_TIn_TOut1_TOut2_TOut3_WhenCalledMultipleTimes_ShouldSetNextParameterEachTime()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+        parameters.GetPreviousParameter<int>().Returns(1, 2);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool)>>();
         function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns(("first", 1.0, true));
@@ -86,21 +84,16 @@ public class MappingFunctionValueTuple3Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first", 1.0, true })));
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second", 2.0, false })));
+        parameters.Received(1).SetNextParameters("first", 1.0, true);
+        parameters.Received(1).SetNextParameters("second", 2.0, false);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char)>>();
         function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns((3.14, true, 'x'));
@@ -111,18 +104,15 @@ public class MappingFunctionValueTuple3Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, true, 'x' })));
+        parameters.Received(1).SetNextParameters(3.14, true, 'x');
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char)>>();
         function
@@ -136,17 +126,15 @@ public class MappingFunctionValueTuple3Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<double>(), Arg.Any<bool>(), Arg.Any<char>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long)>>();
         function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns((3.14, 'x', 100L));
@@ -157,19 +145,15 @@ public class MappingFunctionValueTuple3Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 'x', 100L })));
+        parameters.Received(1).SetNextParameters(3.14, 'x', 100L);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long)>>();
         function
@@ -183,18 +167,15 @@ public class MappingFunctionValueTuple3Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<double>(), Arg.Any<char>(), Arg.Any<long>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short)>>();
         function.InvokeAsync(1, "input", true, 'y', Arg.Any<CancellationToken>()).Returns((3.14, 100L, (short)50));
@@ -205,20 +186,15 @@ public class MappingFunctionValueTuple3Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 100L, (short)50 })));
+        parameters.Received(1).SetNextParameters(3.14, 100L, (short)50);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short)>>();
         function
@@ -238,6 +214,6 @@ public class MappingFunctionValueTuple3Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters.DidNotReceive().SetNextParameters(Arg.Any<double>(), Arg.Any<long>(), Arg.Any<short>());
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple4Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Mapping/MappingFunctionValueTuple4Tests.cs
@@ -9,11 +9,11 @@ namespace ZCrew.StateCraft.UnitTests.Mapping;
 public class MappingFunctionValueTuple4Tests
 {
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
         function.InvokeAsync(42, Arg.Any<CancellationToken>()).Returns(("result", 3.14, true, 'x'));
@@ -24,9 +24,7 @@ public class MappingFunctionValueTuple4Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "result", 3.14, true, 'x' })));
+        parameters.Received(1).SetNextParameters("result", 3.14, true, 'x');
     }
 
     [Fact]
@@ -34,7 +32,7 @@ public class MappingFunctionValueTuple4Tests
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(("result", 3.14, true, 'x'));
@@ -49,11 +47,11 @@ public class MappingFunctionValueTuple4Tests
     }
 
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(42);
+        parameters.GetPreviousParameter<int>().Returns(42);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
         function.InvokeAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException());
@@ -65,15 +63,17 @@ public class MappingFunctionValueTuple4Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters
+            .DidNotReceive()
+            .SetNextParameters(Arg.Any<string>(), Arg.Any<double>(), Arg.Any<bool>(), Arg.Any<char>());
     }
 
     [Fact]
-    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalledMultipleTimes_ShouldSetNextParametersEachTime()
+    public async Task Map_TIn_TOut1_TOut2_TOut3_TOut4_WhenCalledMultipleTimes_ShouldSetNextParameterEachTime()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1, 2);
+        parameters.GetPreviousParameter<int>().Returns(1, 2);
 
         var function = Substitute.For<IAsyncFunc<int, (string, double, bool, char)>>();
         function.InvokeAsync(1, Arg.Any<CancellationToken>()).Returns(("first", 1.0, true, 'a'));
@@ -86,21 +86,16 @@ public class MappingFunctionValueTuple4Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "first", 1.0, true, 'a' })));
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { "second", 2.0, false, 'b' })));
+        parameters.Received(1).SetNextParameters("first", 1.0, true, 'a');
+        parameters.Received(1).SetNextParameters("second", 2.0, false, 'b');
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char, long)>>();
         function.InvokeAsync(1, "input", Arg.Any<CancellationToken>()).Returns((3.14, true, 'x', 100L));
@@ -111,18 +106,15 @@ public class MappingFunctionValueTuple4Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, true, 'x', 100L })));
+        parameters.Received(1).SetNextParameters(3.14, true, 'x', 100L);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
+        parameters.GetPreviousParameters<int, string>().Returns((1, "input"));
 
         var function = Substitute.For<IAsyncFunc<int, string, (double, bool, char, long)>>();
         function
@@ -136,17 +128,17 @@ public class MappingFunctionValueTuple4Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters
+            .DidNotReceive()
+            .SetNextParameters(Arg.Any<double>(), Arg.Any<bool>(), Arg.Any<char>(), Arg.Any<long>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long, short)>>();
         function.InvokeAsync(1, "input", true, Arg.Any<CancellationToken>()).Returns((3.14, 'x', 100L, (short)50));
@@ -157,19 +149,15 @@ public class MappingFunctionValueTuple4Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 'x', 100L, (short)50 })));
+        parameters.Received(1).SetNextParameters(3.14, 'x', 100L, (short)50);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
+        parameters.GetPreviousParameters<int, string, bool>().Returns((1, "input", true));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, (double, char, long, short)>>();
         function
@@ -183,18 +171,17 @@ public class MappingFunctionValueTuple4Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters
+            .DidNotReceive()
+            .SetNextParameters(Arg.Any<double>(), Arg.Any<char>(), Arg.Any<long>(), Arg.Any<short>());
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParametersFromFunctionResult()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_TOut4_WhenCalled_ShouldSetNextParameterFromFunctionResult()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short, byte)>>();
         function
@@ -207,22 +194,15 @@ public class MappingFunctionValueTuple4Tests
         await mapper.Map(parameters, TestContext.Current.CancellationToken);
 
         // Assert
-        parameters
-            .Received(1)
-            .SetNextParameters(
-                Arg.Is<object?[]>(p => p.SequenceEqual(new object?[] { 3.14, 100L, (short)50, (byte)25 }))
-            );
+        parameters.Received(1).SetNextParameters(3.14, 100L, (short)50, (byte)25);
     }
 
     [Fact]
-    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameters()
+    public async Task Map_TIn1_TIn2_TIn3_TIn4_TOut1_TOut2_TOut3_TOut4_WhenFunctionThrows_ShouldNotSetNextParameter()
     {
         // Arrange
         var parameters = Substitute.For<IStateMachineParameters>();
-        parameters.GetPreviousParameter<int>(0).Returns(1);
-        parameters.GetPreviousParameter<string>(1).Returns("input");
-        parameters.GetPreviousParameter<bool>(2).Returns(true);
-        parameters.GetPreviousParameter<char>(3).Returns('y');
+        parameters.GetPreviousParameters<int, string, bool, char>().Returns((1, "input", true, 'y'));
 
         var function = Substitute.For<IAsyncFunc<int, string, bool, char, (double, long, short, byte)>>();
         function
@@ -242,6 +222,8 @@ public class MappingFunctionValueTuple4Tests
 
         // Assert
         await Assert.ThrowsAsync<InvalidOperationException>(act);
-        parameters.DidNotReceive().SetNextParameters(Arg.Any<object?[]>());
+        parameters
+            .DidNotReceive()
+            .SetNextParameters(Arg.Any<double>(), Arg.Any<long>(), Arg.Any<short>(), Arg.Any<byte>());
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Parameters/StateMachineParametersTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Parameters/StateMachineParametersTests.cs
@@ -6,397 +6,758 @@ namespace ZCrew.StateCraft.UnitTests.Parameters;
 public class StateMachineParametersTests
 {
     [Fact]
-    public void GetCurrentParameter_String_WhenParameterExists_ShouldReturnValue()
+    public void SetNextParameter_T_WhenCalled_ShouldStageParameter()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["test-value"]);
-        parameters.CommitTransition();
 
         // Act
-        var result = parameters.GetCurrentParameter<string>(0);
+        parameters.SetNextParameter("staged");
 
         // Assert
-        Assert.Equal("test-value", result);
+        var result = parameters.GetNextParameter<string>();
+        Assert.Equal("staged", result);
     }
 
     [Fact]
-    public void GetCurrentParameter_WhenMultipleParametersExist_ShouldReturnCorrectValueAtEachIndex()
+    public void SetNextParameter_T_WhenCalled_ShouldStoreType()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first", 42, true]);
-        parameters.CommitTransition();
 
         // Act
-        var stringResult = parameters.GetCurrentParameter<string>(0);
-        var intResult = parameters.GetCurrentParameter<int>(1);
-        var boolResult = parameters.GetCurrentParameter<bool>(2);
+        parameters.SetNextParameter("value");
 
         // Assert
-        Assert.Equal("first", stringResult);
-        Assert.Equal(42, intResult);
-        Assert.True(boolResult);
+        var types = parameters.NextParameterTypes;
+        Assert.Single(types);
+        Assert.Equal(typeof(string), types[0]);
     }
 
     [Fact]
-    public void GetCurrentParameter_String_WhenParameterIsNull_ShouldReturnDefault()
+    public void SetNextParameter_T_WhenCalledMultipleTimes_ShouldOverwritePrevious()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters([null]);
-        parameters.CommitTransition();
+        parameters.SetNextParameter("first");
 
         // Act
-        var result = parameters.GetCurrentParameter<string?>(0);
+        parameters.SetNextParameter("second");
 
         // Assert
+        var result = parameters.GetNextParameter<string>();
+        Assert.Equal("second", result);
+    }
+
+    [Fact]
+    public void SetNextParameter_T_WhenCalledWithNull_ShouldSetNull()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("original");
+
+        // Act
+        parameters.SetNextParameter<string?>(null);
+
+        // Assert
+        var result = parameters.GetNextParameter<string?>();
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetCurrentParameter_String_WhenIndexIsNegative_ShouldThrowArgumentException()
+    public void SetNextParameter_T_WhenCommitted_ShouldBeAccessibleAsCurrent()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-        parameters.CommitTransition();
+        parameters.SetNextParameter("value");
 
         // Act
-        var act = object () => parameters.GetCurrentParameter<string>(-1);
+        parameters.CommitTransition();
 
         // Assert
-        Assert.Throws<ArgumentException>(act);
+        Assert.Equal("value", parameters.GetCurrentParameter<string>());
     }
 
     [Fact]
-    public void GetCurrentParameter_String_WhenIndexExceedsCount_ShouldThrowArgumentException()
+    public void SetNextParameters_T1_T2_WhenCalled_ShouldStageParameters()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-        parameters.CommitTransition();
 
         // Act
-        var act = object () => parameters.GetCurrentParameter<string>(1);
+        parameters.SetNextParameters("first", 42);
 
         // Assert
-        Assert.Throws<ArgumentException>(act);
+        var (s, i) = parameters.GetNextParameters<string, int>();
+        Assert.Equal("first", s);
+        Assert.Equal(42, i);
     }
 
     [Fact]
-    public void GetCurrentParameter_String_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    public void SetNextParameters_T1_T2_WhenCalled_ShouldStoreTypes()
     {
         // Arrange
         var parameters = new StateMachineParameters();
 
         // Act
-        var act = object () => parameters.GetCurrentParameter<string>(0);
+        parameters.SetNextParameters("first", 42);
+
+        // Assert
+        var types = parameters.NextParameterTypes;
+        Assert.Equal(2, types.Count);
+        Assert.Equal(typeof(string), types[0]);
+        Assert.Equal(typeof(int), types[1]);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_WhenCommitted_ShouldBeAccessibleAsCurrent()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42);
+
+        // Act
+        parameters.CommitTransition();
+
+        // Assert
+        var (s, i) = parameters.GetCurrentParameters<string, int>();
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_T3_WhenCalled_ShouldStageParameters()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        parameters.SetNextParameters("first", 42, true);
+
+        // Assert
+        var (s, i, b) = parameters.GetNextParameters<string, int, bool>();
+        Assert.Equal("first", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_T3_WhenCalled_ShouldStoreTypes()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        parameters.SetNextParameters("first", 42, true);
+
+        // Assert
+        var types = parameters.NextParameterTypes;
+        Assert.Equal(3, types.Count);
+        Assert.Equal(typeof(string), types[0]);
+        Assert.Equal(typeof(int), types[1]);
+        Assert.Equal(typeof(bool), types[2]);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_T3_WhenCommitted_ShouldBeAccessibleAsCurrent()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+
+        // Act
+        parameters.CommitTransition();
+
+        // Assert
+        var (s, i, b) = parameters.GetCurrentParameters<string, int, bool>();
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_T3_T4_WhenCalled_ShouldStageParameters()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        parameters.SetNextParameters("first", 42, true, 'x');
+
+        // Assert
+        var (s, i, b, c) = parameters.GetNextParameters<string, int, bool, char>();
+        Assert.Equal("first", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+        Assert.Equal('x', c);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_T3_T4_WhenCalled_ShouldStoreTypes()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        parameters.SetNextParameters("first", 42, true, 'x');
+
+        // Assert
+        var types = parameters.NextParameterTypes;
+        Assert.Equal(4, types.Count);
+        Assert.Equal(typeof(string), types[0]);
+        Assert.Equal(typeof(int), types[1]);
+        Assert.Equal(typeof(bool), types[2]);
+        Assert.Equal(typeof(char), types[3]);
+    }
+
+    [Fact]
+    public void SetNextParameters_T1_T2_T3_T4_WhenCommitted_ShouldBeAccessibleAsCurrent()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true, 'x');
+
+        // Act
+        parameters.CommitTransition();
+
+        // Assert
+        var (s, i, b, c) = parameters.GetCurrentParameters<string, int, bool, char>();
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+        Assert.Equal('x', c);
+    }
+
+    [Fact]
+    public void SetEmptyNextParameters_WhenCalled_ShouldSetNextParametersSetFlag()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        parameters.SetEmptyNextParameters();
+
+        // Assert
+        Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet));
+    }
+
+    [Fact]
+    public void SetEmptyNextParameters_WhenCalled_ShouldHaveZeroParameterCount()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        parameters.SetEmptyNextParameters();
+
+        // Assert
+        var types = parameters.NextParameterTypes;
+        Assert.Empty(types);
+    }
+
+    [Fact]
+    public void SetEmptyNextParameters_WhenCalled_ShouldThrowOnGetNextParameter()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetEmptyNextParameters();
+
+        // Act
+        var act = () => parameters.GetNextParameter<string>();
 
         // Assert
         Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
-    public void GetCurrentParameter_Int_WhenTypeMismatch_ShouldThrowArgumentException()
+    public void SetEmptyNextParameters_WhenCommitted_ShouldBeAccessibleAsCurrent()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["string-value"]);
-        parameters.CommitTransition();
+        parameters.SetEmptyNextParameters();
 
         // Act
-        var act = () => (object)parameters.GetCurrentParameter<int>(0);
+        parameters.CommitTransition();
 
         // Assert
-        Assert.Throws<ArgumentException>(act);
+        Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.CurrentParametersSet));
+        Assert.Empty(parameters.CurrentParameterTypes);
     }
 
     [Fact]
-    public void GetPreviousParameter_String_WhenParameterExists_ShouldReturnValue()
+    public void GetPreviousParameter_T_WhenParameterExists_ShouldReturnValue()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["previous-value"]);
+        parameters.SetNextParameter("previous-value");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
         // Act
-        var result = parameters.GetPreviousParameter<string>(0);
+        var result = parameters.GetPreviousParameter<string>();
 
         // Assert
         Assert.Equal("previous-value", result);
     }
 
     [Fact]
-    public void GetPreviousParameter_WhenMultipleParametersExist_ShouldReturnCorrectValueAtEachIndex()
+    public void GetPreviousParameter_T_WhenParameterIsNull_ShouldReturnDefault()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first", 42, true]);
+        parameters.SetNextParameter<string?>(null);
         parameters.CommitTransition();
         parameters.BeginTransition();
 
         // Act
-        var stringResult = parameters.GetPreviousParameter<string>(0);
-        var intResult = parameters.GetPreviousParameter<int>(1);
-        var boolResult = parameters.GetPreviousParameter<bool>(2);
-
-        // Assert
-        Assert.Equal("first", stringResult);
-        Assert.Equal(42, intResult);
-        Assert.True(boolResult);
-    }
-
-    [Fact]
-    public void GetPreviousParameter_String_WhenParameterIsNull_ShouldReturnDefault()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters([null]);
-        parameters.CommitTransition();
-        parameters.BeginTransition();
-
-        // Act
-        var result = parameters.GetPreviousParameter<string?>(0);
+        var result = parameters.GetPreviousParameter<string?>();
 
         // Assert
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetPreviousParameter_String_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-        parameters.CommitTransition();
-        parameters.BeginTransition();
-
-        // Act
-        var act = object () => parameters.GetPreviousParameter<string>(-1);
-
-        // Assert
-        Assert.Throws<ArgumentOutOfRangeException>(act);
-    }
-
-    [Fact]
-    public void GetPreviousParameter_String_WhenIndexExceedsCount_ShouldThrowArgumentOutOfRangeException()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-        parameters.CommitTransition();
-        parameters.BeginTransition();
-
-        // Act
-        var act = object () => parameters.GetPreviousParameter<string>(1);
-
-        // Assert
-        Assert.Throws<ArgumentOutOfRangeException>(act);
-    }
-
-    [Fact]
-    public void GetPreviousParameter_String_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    public void GetPreviousParameter_T_WhenNoParametersSet_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
 
         // Act
-        var act = object () => parameters.GetPreviousParameter<string>(0);
+        var act = () => parameters.GetPreviousParameter<string>();
 
         // Assert
         Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
-    public void GetPreviousParameter_Int_WhenTypeMismatch_ShouldThrowArgumentException()
+    public void GetPreviousParameter_Int_WhenTypeMismatch_ShouldThrowInvalidCastException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["string-value"]);
+        parameters.SetNextParameter("string-value");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
         // Act
-        var act = () => (object)parameters.GetPreviousParameter<int>(0);
+        var act = () => (object)parameters.GetPreviousParameter<int>();
 
         // Assert
-        Assert.Throws<ArgumentException>(act);
+        Assert.Throws<InvalidCastException>(act);
     }
 
     [Fact]
-    public void GetNextParameter_String_WhenParameterExists_ShouldReturnValue()
+    public void GetPreviousParameters_T1_T2_WhenParametersExist_ShouldReturnValues()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["next-value"]);
+        parameters.SetNextParameters("value", 42);
+        parameters.CommitTransition();
+        parameters.BeginTransition();
 
         // Act
-        var result = parameters.GetNextParameter<string>(0);
+        var (s, i) = parameters.GetPreviousParameters<string, int>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+    }
+
+    [Fact]
+    public void GetPreviousParameters_T1_T2_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("value");
+        parameters.CommitTransition();
+        parameters.BeginTransition();
+
+        // Act
+        Action act = () => parameters.GetPreviousParameters<string, int>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetPreviousParameters_T1_T2_T3_WhenParametersExist_ShouldReturnValues()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+        parameters.CommitTransition();
+        parameters.BeginTransition();
+
+        // Act
+        var (s, i, b) = parameters.GetPreviousParameters<string, int, bool>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+    }
+
+    [Fact]
+    public void GetPreviousParameters_T1_T2_T3_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42);
+        parameters.CommitTransition();
+        parameters.BeginTransition();
+
+        // Act
+        Action act = () => parameters.GetPreviousParameters<string, int, bool>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetPreviousParameters_T1_T2_T3_T4_WhenParametersExist_ShouldReturnValues()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true, 'x');
+        parameters.CommitTransition();
+        parameters.BeginTransition();
+
+        // Act
+        var (s, i, b, c) = parameters.GetPreviousParameters<string, int, bool, char>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+        Assert.Equal('x', c);
+    }
+
+    [Fact]
+    public void GetPreviousParameters_T1_T2_T3_T4_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+        parameters.CommitTransition();
+        parameters.BeginTransition();
+
+        // Act
+        Action act = () => parameters.GetPreviousParameters<string, int, bool, char>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetCurrentParameter_T_WhenParameterExists_ShouldReturnValue()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("test-value");
+        parameters.CommitTransition();
+
+        // Act
+        var result = parameters.GetCurrentParameter<string>();
+
+        // Assert
+        Assert.Equal("test-value", result);
+    }
+
+    [Fact]
+    public void GetCurrentParameter_T_WhenParameterIsNull_ShouldReturnDefault()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter<string?>(null);
+        parameters.CommitTransition();
+
+        // Act
+        var result = parameters.GetCurrentParameter<string?>();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetCurrentParameter_T_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        var act = () => parameters.GetCurrentParameter<string>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetCurrentParameter_Int_WhenTypeMismatch_ShouldThrowInvalidCastException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("string-value");
+        parameters.CommitTransition();
+
+        // Act
+        var act = () => (object)parameters.GetCurrentParameter<int>();
+
+        // Assert
+        Assert.Throws<InvalidCastException>(act);
+    }
+
+    [Fact]
+    public void GetCurrentParameters_T1_T2_WhenParametersExist_ShouldReturnValues()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42);
+        parameters.CommitTransition();
+
+        // Act
+        var (s, i) = parameters.GetCurrentParameters<string, int>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+    }
+
+    [Fact]
+    public void GetCurrentParameters_T1_T2_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("value");
+        parameters.CommitTransition();
+
+        // Act
+        Action act = () => parameters.GetCurrentParameters<string, int>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetCurrentParameters_T1_T2_T3_WhenParametersExist_ShouldReturnValues()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+        parameters.CommitTransition();
+
+        // Act
+        var (s, i, b) = parameters.GetCurrentParameters<string, int, bool>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+    }
+
+    [Fact]
+    public void GetCurrentParameters_T1_T2_T3_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42);
+        parameters.CommitTransition();
+
+        // Act
+        Action act = () => parameters.GetCurrentParameters<string, int, bool>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetCurrentParameters_T1_T2_T3_T4_WhenParametersExist_ShouldReturnValues()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true, 'x');
+        parameters.CommitTransition();
+
+        // Act
+        var (s, i, b, c) = parameters.GetCurrentParameters<string, int, bool, char>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+        Assert.Equal('x', c);
+    }
+
+    [Fact]
+    public void GetCurrentParameters_T1_T2_T3_T4_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+        parameters.CommitTransition();
+
+        // Act
+        Action act = () => parameters.GetCurrentParameters<string, int, bool, char>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetNextParameter_T_WhenParameterExists_ShouldReturnValue()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("next-value");
+
+        // Act
+        var result = parameters.GetNextParameter<string>();
 
         // Assert
         Assert.Equal("next-value", result);
     }
 
     [Fact]
-    public void GetNextParameter_WhenMultipleParametersExist_ShouldReturnCorrectValueAtEachIndex()
+    public void GetNextParameter_T_WhenParameterIsNull_ShouldReturnDefault()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first", 42, true]);
+        parameters.SetNextParameter<string?>(null);
 
         // Act
-        var stringResult = parameters.GetNextParameter<string>(0);
-        var intResult = parameters.GetNextParameter<int>(1);
-        var boolResult = parameters.GetNextParameter<bool>(2);
-
-        // Assert
-        Assert.Equal("first", stringResult);
-        Assert.Equal(42, intResult);
-        Assert.True(boolResult);
-    }
-
-    [Fact]
-    public void GetNextParameter_String_WhenParameterIsNull_ShouldReturnDefault()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters([null]);
-
-        // Act
-        var result = parameters.GetNextParameter<string?>(0);
+        var result = parameters.GetNextParameter<string?>();
 
         // Assert
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetNextParameter_String_WhenIndexIsNegative_ShouldThrowArgumentException()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-
-        // Act
-        var act = object () => parameters.GetNextParameter<string>(-1);
-
-        // Assert
-        Assert.Throws<ArgumentException>(act);
-    }
-
-    [Fact]
-    public void GetNextParameter_String_WhenIndexExceedsCount_ShouldThrowArgumentException()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-
-        // Act
-        var act = object () => parameters.GetNextParameter<string>(1);
-
-        // Assert
-        Assert.Throws<ArgumentException>(act);
-    }
-
-    [Fact]
-    public void GetNextParameter_String_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    public void GetNextParameter_T_WhenNoParametersSet_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
 
         // Act
-        var act = object () => parameters.GetNextParameter<string>(0);
+        var act = () => parameters.GetNextParameter<string>();
 
         // Assert
         Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
-    public void GetNextParameter_Int_WhenTypeMismatch_ShouldThrowArgumentException()
+    public void GetNextParameter_T_WhenEmptyParametersSet_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["string-value"]);
+        parameters.SetEmptyNextParameters();
 
         // Act
-        var act = () => (object)parameters.GetNextParameter<int>(0);
+        var act = () => parameters.GetNextParameter<string>();
 
         // Assert
-        Assert.Throws<ArgumentException>(act);
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
-    public void SetNextParameters_WhenCalled_ShouldStageParameters()
+    public void GetNextParameter_Int_WhenTypeMismatch_ShouldThrowInvalidCastException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("string-value");
 
         // Act
-        parameters.SetNextParameters(["staged"]);
+        var act = () => (object)parameters.GetNextParameter<int>();
 
         // Assert
-        var result = parameters.GetNextParameter<string>(0);
-        Assert.Equal("staged", result);
+        Assert.Throws<InvalidCastException>(act);
     }
 
     [Fact]
-    public void SetNextParameters_WhenCalledMultipleTimes_ShouldOverwritePrevious()
+    public void GetNextParameters_T1_T2_WhenParametersExist_ShouldReturnValues()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first"]);
+        parameters.SetNextParameters("value", 42);
 
         // Act
-        parameters.SetNextParameters(["second"]);
+        var (s, i) = parameters.GetNextParameters<string, int>();
 
         // Assert
-        var result = parameters.GetNextParameter<string>(0);
-        Assert.Equal("second", result);
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
     }
 
     [Fact]
-    public void SetNextParameters_WhenCalledWithEmptyArray_ShouldSetZeroParameters()
+    public void GetNextParameters_T1_T2_WhenCountTooLow_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("value");
 
         // Act
-        parameters.SetNextParameters([]);
+        Action act = () => parameters.GetNextParameters<string, int>();
 
         // Assert
-        var act = object () => parameters.GetNextParameter<string>(0);
-        Assert.Throws<ArgumentException>(act);
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
-    public void SetNextParameters_WhenCalledWithMaxParameters_ShouldSucceed()
+    public void GetNextParameters_T1_T2_T3_WhenParametersExist_ShouldReturnValues()
     {
         // Arrange
         var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
 
         // Act
-        parameters.SetNextParameters(["one", "two", "three", "four"]);
-        parameters.CommitTransition();
+        var (s, i, b) = parameters.GetNextParameters<string, int, bool>();
 
         // Assert
-        Assert.Equal("one", parameters.GetCurrentParameter<string>(0));
-        Assert.Equal("two", parameters.GetCurrentParameter<string>(1));
-        Assert.Equal("three", parameters.GetCurrentParameter<string>(2));
-        Assert.Equal("four", parameters.GetCurrentParameter<string>(3));
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
     }
 
     [Fact]
-    public void SetNextParameters_WhenCalledWithMoreThanMaxParameters_ShouldThrowArgumentException()
+    public void GetNextParameters_T1_T2_T3_WhenCountTooLow_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42);
 
         // Act
-        var act = () => parameters.SetNextParameters(["one", "two", "three", "four", "five"]);
+        Action act = () => parameters.GetNextParameters<string, int, bool>();
 
         // Assert
-        Assert.Throws<ArgumentException>(act);
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void GetNextParameters_T1_T2_T3_T4_WhenParametersExist_ShouldReturnValues()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true, 'x');
+
+        // Act
+        var (s, i, b, c) = parameters.GetNextParameters<string, int, bool, char>();
+
+        // Assert
+        Assert.Equal("value", s);
+        Assert.Equal(42, i);
+        Assert.True(b);
+        Assert.Equal('x', c);
+    }
+
+    [Fact]
+    public void GetNextParameters_T1_T2_T3_T4_WhenCountTooLow_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+
+        // Act
+        Action act = () => parameters.GetNextParameters<string, int, bool, char>();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
@@ -404,14 +765,14 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["current-value"]);
+        parameters.SetNextParameter("current-value");
         parameters.CommitTransition();
 
         // Act
         parameters.BeginTransition();
 
         // Assert
-        var result = parameters.GetPreviousParameter<string>(0);
+        var result = parameters.GetPreviousParameter<string>();
         Assert.Equal("current-value", result);
     }
 
@@ -420,14 +781,14 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["current-value"]);
+        parameters.SetNextParameter("current-value");
         parameters.CommitTransition();
 
         // Act
         parameters.BeginTransition();
 
         // Assert
-        var act = object () => parameters.GetCurrentParameter<string>(0);
+        var act = () => parameters.GetCurrentParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
     }
 
@@ -446,17 +807,34 @@ public class StateMachineParametersTests
     }
 
     [Fact]
+    public void BeginTransition_WithMultipleParameters_ShouldMoveAllToPrevious()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("state-A", 100);
+        parameters.CommitTransition();
+
+        // Act
+        parameters.BeginTransition();
+
+        // Assert
+        var (s, i) = parameters.GetPreviousParameters<string, int>();
+        Assert.Equal("state-A", s);
+        Assert.Equal(100, i);
+    }
+
+    [Fact]
     public void CommitTransition_WhenCalled_ShouldMoveNextToCurrent()
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["next-value"]);
+        parameters.SetNextParameter("next-value");
 
         // Act
         parameters.CommitTransition();
 
         // Assert
-        var result = parameters.GetCurrentParameter<string>(0);
+        var result = parameters.GetCurrentParameter<string>();
         Assert.Equal("next-value", result);
     }
 
@@ -465,13 +843,13 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["next-value"]);
+        parameters.SetNextParameter("next-value");
 
         // Act
         parameters.CommitTransition();
 
         // Assert
-        var act = object () => parameters.GetNextParameter<string>(0);
+        var act = () => parameters.GetNextParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
     }
 
@@ -480,48 +858,17 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first"]);
+        parameters.SetNextParameter("first");
         parameters.CommitTransition();
         parameters.BeginTransition();
-        parameters.SetNextParameters(["second"]);
+        parameters.SetNextParameter("second");
 
         // Act
         parameters.CommitTransition();
 
         // Assert
-        var act = object () => parameters.GetPreviousParameter<string>(0);
+        var act = () => parameters.GetPreviousParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
-    }
-
-    [Fact]
-    public void CommitTransition_WhenCalled_ShouldClearNextParametersSetFlag()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
-
-        // Act
-        parameters.CommitTransition();
-
-        // Assert
-        Assert.False(parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet));
-    }
-
-    [Fact]
-    public void CommitTransition_WhenCalled_ShouldClearPreviousParametersSetFlag()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first"]);
-        parameters.CommitTransition();
-        parameters.BeginTransition();
-        parameters.SetNextParameters(["second"]);
-
-        // Act
-        parameters.CommitTransition();
-
-        // Assert
-        Assert.False(parameters.Status.HasFlag(StateMachineParametersFlags.PreviousParametersSet));
     }
 
     [Fact]
@@ -529,20 +876,39 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["state-A", 100]);
+        parameters.SetNextParameters("state-A", 100);
         parameters.CommitTransition();
         parameters.BeginTransition();
-        parameters.SetNextParameters(["state-B", 200]);
+        parameters.SetNextParameters("state-B", 200);
 
         // Act
         parameters.CommitTransition();
 
         // Assert
-        Assert.Equal("state-B", parameters.GetCurrentParameter<string>(0));
-        Assert.Equal(200, parameters.GetCurrentParameter<int>(1));
+        var (s, i) = parameters.GetCurrentParameters<string, int>();
+        Assert.Equal("state-B", s);
+        Assert.Equal(200, i);
         Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.CurrentParametersSet));
         Assert.False(parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet));
         Assert.False(parameters.Status.HasFlag(StateMachineParametersFlags.PreviousParametersSet));
+    }
+
+    [Fact]
+    public void CommitTransition_WhenTypesStored_ShouldPreserveTypesInCurrent()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameters("value", 42, true);
+
+        // Act
+        parameters.CommitTransition();
+
+        // Assert
+        var types = parameters.CurrentParameterTypes;
+        Assert.Equal(3, types.Count);
+        Assert.Equal(typeof(string), types[0]);
+        Assert.Equal(typeof(int), types[1]);
+        Assert.Equal(typeof(bool), types[2]);
     }
 
     [Fact]
@@ -550,7 +916,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["original"]);
+        parameters.SetNextParameter("original");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
@@ -558,7 +924,7 @@ public class StateMachineParametersTests
         parameters.RollbackTransition();
 
         // Assert
-        var result = parameters.GetCurrentParameter<string>(0);
+        var result = parameters.GetCurrentParameter<string>();
         Assert.Equal("original", result);
     }
 
@@ -567,7 +933,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["original"]);
+        parameters.SetNextParameter("original");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
@@ -575,7 +941,7 @@ public class StateMachineParametersTests
         parameters.RollbackTransition();
 
         // Assert
-        var act = object () => parameters.GetPreviousParameter<string>(0);
+        var act = () => parameters.GetPreviousParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
     }
 
@@ -584,16 +950,16 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["original"]);
+        parameters.SetNextParameter("original");
         parameters.CommitTransition();
         parameters.BeginTransition();
-        parameters.SetNextParameters(["staged"]);
+        parameters.SetNextParameter("staged");
 
         // Act
         parameters.RollbackTransition();
 
         // Assert
-        var act = object () => parameters.GetNextParameter<string>(0);
+        var act = () => parameters.GetNextParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
     }
 
@@ -602,10 +968,10 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["original"]);
+        parameters.SetNextParameter("original");
         parameters.CommitTransition();
         parameters.BeginTransition();
-        parameters.SetNextParameters(["staged"]);
+        parameters.SetNextParameter("staged");
 
         // Act
         parameters.RollbackTransition();
@@ -619,16 +985,16 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["original"]);
+        parameters.SetNextParameter("original");
         parameters.CommitTransition();
         parameters.BeginTransition();
-        parameters.SetNextParameters(["new-value"]);
+        parameters.SetNextParameter("new-value");
 
         // Act
         parameters.RollbackTransition();
 
         // Assert
-        Assert.Equal("original", parameters.GetCurrentParameter<string>(0));
+        Assert.Equal("original", parameters.GetCurrentParameter<string>());
         Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.CurrentParametersSet));
         Assert.False(parameters.Status.HasFlag(StateMachineParametersFlags.PreviousParametersSet));
         Assert.False(parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet));
@@ -648,26 +1014,13 @@ public class StateMachineParametersTests
     }
 
     [Fact]
-    public void Status_AfterSetNextParameters_ShouldHaveNextParametersSet()
+    public void Status_AfterSetNextParameter_ShouldHaveNextParametersSet()
     {
         // Arrange
         var parameters = new StateMachineParameters();
 
         // Act
-        parameters.SetNextParameters(["value"]);
-
-        // Assert
-        Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet));
-    }
-
-    [Fact]
-    public void Status_AfterSetNextParametersWithEmptyArray_ShouldHaveNextParametersSet()
-    {
-        // Arrange
-        var parameters = new StateMachineParameters();
-
-        // Act
-        parameters.SetNextParameters([]);
+        parameters.SetNextParameter("value");
 
         // Assert
         Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet));
@@ -678,7 +1031,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
         parameters.CommitTransition();
 
         // Act
@@ -693,7 +1046,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
         parameters.CommitTransition();
 
         // Act
@@ -708,7 +1061,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
 
         // Act
         parameters.CommitTransition();
@@ -722,7 +1075,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
 
         // Act
         parameters.CommitTransition();
@@ -736,7 +1089,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
@@ -752,7 +1105,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
@@ -768,7 +1121,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
@@ -784,7 +1137,7 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["first"]);
+        parameters.SetNextParameter("first");
         parameters.CommitTransition();
         parameters.BeginTransition();
 
@@ -792,7 +1145,7 @@ public class StateMachineParametersTests
         parameters.Clear();
 
         // Assert
-        var act = object () => parameters.GetPreviousParameter<string>(0);
+        var act = () => parameters.GetPreviousParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
     }
 
@@ -801,14 +1154,14 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
         parameters.CommitTransition();
 
         // Act
         parameters.Clear();
 
         // Assert
-        var act = object () => parameters.GetCurrentParameter<string>(0);
+        var act = () => parameters.GetCurrentParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
     }
 
@@ -817,13 +1170,97 @@ public class StateMachineParametersTests
     {
         // Arrange
         var parameters = new StateMachineParameters();
-        parameters.SetNextParameters(["value"]);
+        parameters.SetNextParameter("value");
 
         // Act
         parameters.Clear();
 
         // Assert
-        var act = object () => parameters.GetNextParameter<string>(0);
+        var act = () => parameters.GetNextParameter<string>();
         Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void PreviousParameterTypes_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        var act = () => parameters.PreviousParameterTypes;
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void PreviousParameterTypes_WhenParametersSet_ShouldBeAccessible()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("value");
+        parameters.CommitTransition();
+        parameters.BeginTransition();
+
+        // Act
+        var result = parameters.PreviousParameterTypes;
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void CurrentParameterTypes_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        var act = () => parameters.CurrentParameterTypes;
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void CurrentParameterTypes_WhenParametersSet_ShouldBeAccessible()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("value");
+        parameters.CommitTransition();
+
+        // Act
+        var result = parameters.CurrentParameterTypes;
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void NextParameterTypes_WhenNoParametersSet_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+
+        // Act
+        var act = () => parameters.NextParameterTypes;
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public void NextParameterTypes_WhenParametersSet_ShouldBeAccessible()
+    {
+        // Arrange
+        var parameters = new StateMachineParameters();
+        parameters.SetNextParameter("value");
+
+        // Act
+        var result = parameters.NextParameterTypes;
+
+        // Assert
+        Assert.NotNull(result);
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Stubs/StubStateMachine.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Stubs/StubStateMachine.cs
@@ -54,6 +54,7 @@ internal class StubStateMachine<TState, TTransition> : IStateMachine<TState, TTr
     {
         get =>
             Parameters.Status.HasFlag(StateMachineParametersFlags.NextParametersSet)
+            && Parameters.NextParameterTypes.Count > 0
                 ? Parameters.GetNextParameter<object?>(0)
                 : null;
         set => Parameters.SetNextParameters([value]);


### PR DESCRIPTION
Redesign the `IStateMachineParameters` to supply n-arity methods and expose type parameters of the parameters.

Closes #42