### PR TITLE
#67 - Cleanup StateMachine.cs and rename workflow titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/1-feature.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Request a new feature or enhancement.
-title: "StateCraft: "
+title: "Feature: "
 labels: []
 projects: ["ZCrewSoftware/ZCrew.StateCraft"]
 type: feature

--- a/.github/ISSUE_TEMPLATE/2-bugfix.yaml
+++ b/.github/ISSUE_TEMPLATE/2-bugfix.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report.
-title: "StateCraft: "
+title: "Bug: "
 labels: []
 projects: ["ZCrewSoftware/ZCrew.StateCraft"]
 type: bugfix

--- a/.github/ISSUE_TEMPLATE/3-task.yaml
+++ b/.github/ISSUE_TEMPLATE/3-task.yaml
@@ -1,6 +1,6 @@
 name: Task
 description: Non-functional work such as documentation or changing GitHub settings
-title: "StateCraft: "
+title: "Task: "
 labels: []
 projects: ["ZCrewSoftware/ZCrew.StateCraft"]
 type: task

--- a/.github/ISSUE_TEMPLATE/4-spike.yaml
+++ b/.github/ISSUE_TEMPLATE/4-spike.yaml
@@ -1,6 +1,6 @@
 name: Spike
 description: Exploratory work to create a proof of concept
-title: "StateCraft: "
+title: "Spike: "
 labels: []
 projects: ["ZCrewSoftware/ZCrew.StateCraft"]
 type: spike

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Build all projects
+dotnet build
+```
+
+## Project Structure
+
+- `src/ZCrew.StateCraft/` - Main library (targets net8.0, net9.0, net10.0)
+- `tests/ZCrew.StateCraft.UnitTests/` - Unit tests with NSubstitute mocks
+- `tests/ZCrew.StateCraft.IntegrationTests/` - Integration tests for full state machine behavior
+- `docs/` - User-facing documentation (numbered markdown files)
+
+## Architecture
+
+StateCraft is a fluent async state machine library. The entry point is `StateMachine.Configure<TState, TTransition>()`.
+
+**Key Components:**
+
+- **StateMachine** (`StateMachine.cs`) - Static entry point for fluent configuration
+- **StateMachineConfiguration** (`StateMachines/StateMachineConfiguration.cs`) - Builds state machines from configuration
+- **StateMachine<TState, TTransition>** (`StateMachines/StateMachine.cs`) - Runtime state machine with thread-safe transitions using AsyncLock
+
+**State/Transition Pattern:**
+- States and transitions are configured via `IStateConfiguration` interfaces in `States/Configuration/`
+- Parameterless states (`ParameterlessState`) and parameterized states (`ParameterizedState<T>`, `State<T1,T2>`, `State<T1,T2,T3>`, `State<T1,T2,T3,T4>`) in `States/`
+- States support up to 4 typed parameters configured via `WithParameter<T>()` (single) or `WithParameters<T1,T2>()` etc. (multi)
+- Transitions can be parameterless, parameterized, mapped (type conversion), or reentrant (same parameter) in `Transitions/`
+- All handlers (lifecycle, actions, triggers, conditions) support three signatures: sync (`Action`), async `Task`, and async `ValueTask`
+
+**Internal State Flow:**
+The state machine tracks internal state through: `Inactive -> Idle -> Active` with transition states: `Exiting -> Exited -> Transitioning -> Transitioned -> Entering -> Entered`. A `Recovery` state handles rollback on failures.
+
+**Validation:** Build-time validators in `Validation/` check for duplicate states, unreachable transitions, and invalid transition targets. Enable with `Build(StateMachineBuildOptions.Validate)`.
+
+**Configuration Reuse:** `IStateMachineConfiguration` is reusable; each `Build()` creates an independent state machine instance.
+
+**Exception Handling:** `IExceptionBehavior` (`Exceptions/Contracts/`) wraps each call site (lifecycle, conditions, actions, triggers, mapping) so implementations can intercept exceptions. `DefaultExceptionBehavior` (`Exceptions/`) is used by default and routes caught exceptions through registered `OnException` handlers that return an `ExceptionResult` (`Continue`, `Rethrow`, or `Throw`). Custom implementations can be provided via `.WithExceptionBehavior(handlers => ...)` on the configuration; the provider is called per `Build()`. `DefaultExceptionBehavior` has `virtual` methods and can be subclassed. `OperationCanceledException` when the token is canceled bypasses handlers — rethrown for lifecycle/conditions/mapping, suppressed for actions/triggers.
+
+**Triggers:** Autonomous transition initiators (`RunOnceTrigger`, `RepeatingTrigger`) configured at the machine level (not on individual states) that activate/deactivate with the state machine.
+
+## API Quick Reference
+
+**Runtime methods on `IStateMachine<TState, TTransition>`:**
+- `Activate()` / `Deactivate()` - start/stop the state machine (not StartAsync/StopAsync)
+- `Transition(transition)` / `Transition(transition, param)` / `Transition<T1,T2>(transition, p1, p2)` etc. up to 4 params
+- `CanTransition(transition)` / `CanTransition<T1,T2>(transition, p1, p2)` etc. up to 4 params
+- `TryTransition(transition)` / `TryTransition<T1,T2>(transition, p1, p2)` etc. up to 4 params
+
+**Configuration patterns:**
+- Initial state (required): `.WithInitialState(State.X)` or `.WithInitialState<T>(State.X, param)` or `.WithInitialState<T1,T2>(State.X, p1, p2)` etc.
+- Single-parameter states: `.WithState(State.X, s => s.WithParameter<T>()...)` (no generic on WithState)
+- Multi-parameter states: `.WithState(State.X, s => s.WithParameters<T1,T2>()...)` (up to 4 type params)
+- Parameterless transitions: `.WithTransition(Trigger.X, t => t.To(State.Y))` (`WithNoParameters()` is implied)
+- Single-param transitions: `.WithTransition(Trigger.X, t => t.WithParameter<T>().If(...).To(...))`
+- Multi-param transitions: `.WithTransition(Trigger.X, t => t.WithParameters<T1,T2>().To(...))` (up to 4)
+- Mapped transitions (single): `.WithTransition(Trigger.X, t => t.WithMappedParameter<TNext>(prev => ...).To(State.Y))`
+- Mapped transitions (multi): `.WithTransition(Trigger.X, t => t.WithMappedParameters<T1,T2>((prev) => ...).To(State.Y))`
+- Reentrant transitions (single): `.WithTransition(Trigger.X, t => t.WithSameParameter().To(State.Y))`
+- Reentrant transitions (multi): `.WithTransition(Trigger.X, t => t.WithSameParameters().To(State.Y))`
+- Transition shortcuts: `.WithTransition(Trigger.X, State.Y)` — always implies `WithNoParameters()` regardless of source state parameters
+- Actions (parameterless): `.WithAction(a => a.Invoke(async token => ...))`
+- Actions (parameterized): `.WithAction(a => a.Invoke(async (param, token) => ...))` — receives all state parameters
+- Async actions: `.WithAsynchronousActions()` — makes `Transition` return before actions complete
+- Exception behavior: `.WithExceptionBehavior(handlers => new CustomBehavior(handlers))` — replaces default `IExceptionBehavior`; provider called per `Build()`
+- Exception handlers: `.OnException(ex => ExceptionResult.Continue())` — registers handler invoked by the exception behavior
+- Build: `.Build()` or `.Build(StateMachineBuildOptions.Validate)` to validate configuration
+
+**Trigger configuration (on `IStateMachineConfiguration`, not state):**
+```csharp
+.WithTrigger(trigger => trigger
+    .Once()  // or .Repeat()
+    .Await(token => signal.WaitAsync(token))
+    .ThenInvoke(sm => sm.Transition(Trigger.X)))
+```
+
+## Code Style
+
+- Uses CSharpier for formatting (enforced via pre-commit hook and does not ever need to be ran manually)
+- C# 14.0 language version with nullable reference types enabled
+- Test projects use xUnit v3 with NSubstitute for mocking
+- Internal classes are visible to test projects via `InternalsVisibleTo`
+
+**XML Documentation:**
+- XML documentation should be indented (4 spaces for content within tags)
+- Lines should not exceed 120 characters; wrap long descriptions across multiple lines
+- Always document `CancellationToken` parameters as: `<param name="token">The token to monitor for cancellation requests.</param>`

--- a/src/ZCrew.StateCraft/Extensions/InternalStateExtensions.cs
+++ b/src/ZCrew.StateCraft/Extensions/InternalStateExtensions.cs
@@ -1,0 +1,33 @@
+using ZCrew.StateCraft.StateMachines;
+
+namespace ZCrew.StateCraft.Extensions;
+
+/// <summary>
+///     Provides convenience properties for checking common <see cref="InternalState"/> patterns.
+/// </summary>
+internal static class InternalStateExtensions
+{
+    extension(InternalState state)
+    {
+        /// <summary>
+        ///     Gets a value indicating whether the state machine can accept a new transition.
+        /// </summary>
+        public bool CanAcceptTransition =>
+            state is InternalState.Active or InternalState.Recovery or InternalState.Entering;
+
+        /// <summary>
+        ///     Gets a value indicating whether the state machine is entering a state.
+        /// </summary>
+        public bool IsEntering => state is InternalState.Entering;
+
+        /// <summary>
+        ///     Gets a value indicating whether the state machine has been activated.
+        /// </summary>
+        public bool IsActivated => state is not InternalState.Inactive;
+
+        /// <summary>
+        ///     Gets a value indicating whether the state machine is inactive.
+        /// </summary>
+        public bool IsInactive => state is InternalState.Inactive;
+    }
+}

--- a/src/ZCrew.StateCraft/StateMachines/Contracts/IStateMachine.cs
+++ b/src/ZCrew.StateCraft/StateMachines/Contracts/IStateMachine.cs
@@ -1,6 +1,5 @@
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.Tracking.Contracts;
-using ZCrew.StateCraft.Transitions.Contracts;
 
 namespace ZCrew.StateCraft.StateMachines.Contracts;
 
@@ -41,11 +40,6 @@ public interface IStateMachine<TState, TTransition> : IDisposable
     ///     The parameters for the state machine when in a state or transitioning between states.
     /// </summary>
     internal IStateMachineParameters Parameters { get; }
-
-    /// <summary>
-    ///     The current transition that has been started. This will only be present when transitioning.
-    /// </summary>
-    internal ITransition<TState, TTransition>? CurrentTransition { get; }
 
     /// <summary>
     ///     The states in this state machine.

--- a/src/ZCrew.StateCraft/StateMachines/InternalState.cs
+++ b/src/ZCrew.StateCraft/StateMachines/InternalState.cs
@@ -1,0 +1,59 @@
+namespace ZCrew.StateCraft.StateMachines;
+
+/// <summary>
+///     The internal state of the state machine.
+/// </summary>
+internal enum InternalState
+{
+    /// <summary>
+    ///     The state machine has not been activated.
+    /// </summary>
+    Inactive,
+
+    /// <summary>
+    ///     The state machine is active and ready for transitions.
+    /// </summary>
+    Active,
+
+    /// <summary>
+    ///     The state machine has completed activation and is ready to enter the next state.
+    /// </summary>
+    Idle,
+
+    /// <summary>
+    ///     The state machine is exiting a state.
+    /// </summary>
+    Exiting,
+
+    /// <summary>
+    ///     The state machine has exited the state.
+    /// </summary>
+    Exited,
+
+    /// <summary>
+    ///     The state machine is in the process of transitioning between states.
+    /// </summary>
+    Transitioning,
+
+    /// <summary>
+    ///     The state machine has transitioned: setting the next state, setting the next parameter, and has invoked
+    ///     the state change handlers. The state machine is ready to enter the next state.
+    /// </summary>
+    Transitioned,
+
+    /// <summary>
+    ///     The state machine is entering a state.
+    /// </summary>
+    Entering,
+
+    /// <summary>
+    ///     The state machine has entered the state and the state action is ready to be ran.
+    /// </summary>
+    Entered,
+
+    /// <summary>
+    ///     The state machine failed to transition. It was rolled-back to it's previous state but did not re-enter
+    ///     or restart the actions for that state.
+    /// </summary>
+    Recovery,
+}

--- a/src/ZCrew.StateCraft/StateMachines/StateMachine.CanTransition.cs
+++ b/src/ZCrew.StateCraft/StateMachines/StateMachine.CanTransition.cs
@@ -1,0 +1,159 @@
+using ZCrew.StateCraft.Extensions;
+
+namespace ZCrew.StateCraft.StateMachines;
+
+internal partial class StateMachine<TState, TTransition>
+{
+    /// <inheritdoc />
+    public async Task<bool> CanTransition(TTransition transition, CancellationToken token = default)
+    {
+        using var _ = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetEmptyNextParameters();
+            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            return nextTransition != null;
+        }
+        finally
+        {
+            Rollback();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CanTransition<T>(TTransition transition, T parameter, CancellationToken token = default)
+    {
+        using var _ = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameter(parameter);
+            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            return nextTransition != null;
+        }
+        finally
+        {
+            Rollback();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CanTransition<T1, T2>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        CancellationToken token = default
+    )
+    {
+        using var _ = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2);
+            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            return nextTransition != null;
+        }
+        finally
+        {
+            Rollback();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CanTransition<T1, T2, T3>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        CancellationToken token = default
+    )
+    {
+        using var _ = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2, parameter3);
+            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            return nextTransition != null;
+        }
+        finally
+        {
+            Rollback();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CanTransition<T1, T2, T3, T4>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        CancellationToken token = default
+    )
+    {
+        using var _ = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2, parameter3, parameter4);
+            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            return nextTransition != null;
+        }
+        finally
+        {
+            Rollback();
+        }
+    }
+}

--- a/src/ZCrew.StateCraft/StateMachines/StateMachine.Transition.cs
+++ b/src/ZCrew.StateCraft/StateMachines/StateMachine.Transition.cs
@@ -1,0 +1,189 @@
+using ZCrew.StateCraft.Extensions;
+
+namespace ZCrew.StateCraft.StateMachines;
+
+internal partial class StateMachine<TState, TTransition>
+{
+    /// <inheritdoc />
+    public async Task Transition(TTransition transition, CancellationToken token = default)
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            throw new InvalidOperationException("The state machine has not been activated.");
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetEmptyNextParameters();
+            var currentTransition = await PreviousState.GetTransition(transition, Parameters, token);
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+    }
+
+    /// <inheritdoc />
+    public async Task Transition<T>(TTransition transition, T parameter, CancellationToken token = default)
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            throw new InvalidOperationException("The state machine has not been activated.");
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameter(parameter);
+            var currentTransition = await PreviousState.GetTransition(transition, Parameters, token);
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+    }
+
+    /// <inheritdoc />
+    public async Task Transition<T1, T2>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        CancellationToken token = default
+    )
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            throw new InvalidOperationException("The state machine has not been activated.");
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2);
+            var currentTransition = await PreviousState.GetTransition(transition, Parameters, token);
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+    }
+
+    /// <inheritdoc />
+    public async Task Transition<T1, T2, T3>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        CancellationToken token = default
+    )
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            throw new InvalidOperationException("The state machine has not been activated.");
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2, parameter3);
+            var currentTransition = await PreviousState.GetTransition(transition, Parameters, token);
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+    }
+
+    /// <inheritdoc />
+    public async Task Transition<T1, T2, T3, T4>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        CancellationToken token = default
+    )
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            throw new InvalidOperationException("The state machine has not been activated.");
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2, parameter3, parameter4);
+            var currentTransition = await PreviousState.GetTransition(transition, Parameters, token);
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+    }
+}

--- a/src/ZCrew.StateCraft/StateMachines/StateMachine.TryTransition.cs
+++ b/src/ZCrew.StateCraft/StateMachines/StateMachine.TryTransition.cs
@@ -1,0 +1,280 @@
+using ZCrew.StateCraft.Extensions;
+using ZCrew.StateCraft.Transitions.Contracts;
+
+namespace ZCrew.StateCraft.StateMachines;
+
+internal partial class StateMachine<TState, TTransition>
+{
+    /// <inheritdoc />
+    public async Task<bool> TryTransition(TTransition transition, CancellationToken token = default)
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        ITransition<TState, TTransition> currentTransition;
+        try
+        {
+            BeginTransition();
+            Parameters.SetEmptyNextParameters();
+            var resolved = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            if (resolved == null)
+            {
+                Rollback();
+                return false;
+            }
+
+            currentTransition = resolved;
+        }
+        catch
+        {
+            Rollback();
+            throw;
+        }
+
+        try
+        {
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryTransition<T>(TTransition transition, T parameter, CancellationToken token = default)
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        ITransition<TState, TTransition> currentTransition;
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameter(parameter);
+            var resolved = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            if (resolved == null)
+            {
+                Rollback();
+                return false;
+            }
+
+            currentTransition = resolved;
+        }
+        catch
+        {
+            Rollback();
+            throw;
+        }
+
+        try
+        {
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryTransition<T1, T2>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        CancellationToken token = default
+    )
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        ITransition<TState, TTransition> currentTransition;
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2);
+            var resolved = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            if (resolved == null)
+            {
+                Rollback();
+                return false;
+            }
+
+            currentTransition = resolved;
+        }
+        catch
+        {
+            Rollback();
+            throw;
+        }
+
+        try
+        {
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryTransition<T1, T2, T3>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        CancellationToken token = default
+    )
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        ITransition<TState, TTransition> currentTransition;
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2, parameter3);
+            var resolved = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            if (resolved == null)
+            {
+                Rollback();
+                return false;
+            }
+
+            currentTransition = resolved;
+        }
+        catch
+        {
+            Rollback();
+            throw;
+        }
+
+        try
+        {
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryTransition<T1, T2, T3, T4>(
+        TTransition transition,
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        CancellationToken token = default
+    )
+    {
+        using var transitionLock = await this.stateMachineLock.LockAsync(token);
+        if (!this.internalState.CanAcceptTransition)
+        {
+            return false;
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await RetryEntry(token);
+        }
+
+        ITransition<TState, TTransition> currentTransition;
+        try
+        {
+            BeginTransition();
+            Parameters.SetNextParameters(parameter1, parameter2, parameter3, parameter4);
+            var resolved = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
+            if (resolved == null)
+            {
+                Rollback();
+                return false;
+            }
+
+            currentTransition = resolved;
+        }
+        catch
+        {
+            Rollback();
+            throw;
+        }
+
+        try
+        {
+            NextState = currentTransition.Next.State;
+            await ExitState(token);
+            await ExecuteTransition(currentTransition, token);
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+
+        await EnterState(transitionLock, token);
+        return true;
+    }
+}

--- a/src/ZCrew.StateCraft/StateMachines/StateMachine.cs
+++ b/src/ZCrew.StateCraft/StateMachines/StateMachine.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Nito.AsyncEx;
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Parameters;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
@@ -13,7 +14,7 @@ using ZCrew.StateCraft.Triggers.Contracts;
 namespace ZCrew.StateCraft.StateMachines;
 
 /// <inheritdoc />
-internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, TTransition>
+internal sealed partial class StateMachine<TState, TTransition> : IStateMachine<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
@@ -75,7 +76,116 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
     public IStateMachineParameters Parameters { get; } = new StateMachineParameters();
 
     /// <inheritdoc />
-    public ITransition<TState, TTransition>? CurrentTransition { get; set; }
+    public async Task Activate(CancellationToken token = default)
+    {
+        using var activationLock = await this.stateMachineLock.LockAsync(token);
+        if (this.internalState.IsActivated)
+        {
+            throw new InvalidOperationException("The state machine has already been activated.");
+        }
+
+        try
+        {
+            await this.stateMachineActivator.Activate(this, token);
+            Debug.Assert(NextState != null, $"Expected {nameof(NextState)} to be set.");
+
+            await NextState.Activate(Parameters, token);
+            this.internalState = InternalState.Idle;
+            await ActivateTriggers(token);
+            await EnterState(activationLock, token);
+        }
+        catch when (CurrentState == null)
+        {
+            // If there was an exception during activation the state machine is forced to reset fully
+            Parameters.Clear();
+            NextState = null;
+            CurrentState = null;
+            PreviousState = null;
+
+            this.internalState = InternalState.Inactive;
+            await DeactivateTriggers(CancellationToken.None);
+            throw;
+        }
+        catch
+        {
+            await DeactivateTriggers(CancellationToken.None);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task Deactivate(CancellationToken token = default)
+    {
+        using var _ = await this.stateMachineLock.LockAsync(token);
+        if (this.internalState.IsInactive)
+        {
+            throw new InvalidOperationException("The state machine has not been activated.");
+        }
+
+        if (this.internalState.IsEntering)
+        {
+            await DeactivateTriggers(token);
+            Parameters.Clear();
+            PreviousState = null;
+            NextState = null;
+            this.internalState = InternalState.Inactive;
+            return;
+        }
+
+        try
+        {
+            BeginTransition();
+            await ExitState(token);
+            await DeactivateTriggers(token);
+
+            await PreviousState.Deactivate(Parameters, token);
+
+            Parameters.Clear();
+            PreviousState = null;
+            this.internalState = InternalState.Inactive;
+        }
+        catch when (CurrentState == null)
+        {
+            Rollback();
+            this.internalState = InternalState.Recovery;
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task StateChange(
+        TState previousState,
+        TTransition transition,
+        TState nextState,
+        CancellationToken token
+    )
+    {
+        foreach (var onStateChange in this.onStateChanges)
+        {
+            await ExceptionBehavior.CallOnStateChange(
+                t => onStateChange.InvokeAsync(previousState, transition, nextState, t),
+                token
+            );
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddState(IState<TState, TTransition> state)
+    {
+        StateTable.Add(state);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        var actionCts = this.actionCancellationTokenSource;
+
+        this.actionTask = null;
+        this.actionCancellationTokenSource = null;
+
+        actionCts?.Cancel();
+        actionCts?.Dispose();
+    }
 
     private async Task ExitState(CancellationToken token)
     {
@@ -109,17 +219,14 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         this.internalState = InternalState.Exited;
     }
 
-    private async Task Transition(CancellationToken token)
+    private async Task ExecuteTransition(ITransition<TState, TTransition> currentTransition, CancellationToken token)
     {
         Debug.Assert(PreviousState != null, $"Expected {nameof(PreviousState)} to be set.");
-        Debug.Assert(CurrentTransition != null, $"Expected {nameof(CurrentTransition)} to be set.");
         Debug.Assert(NextState != null, $"Expected {nameof(NextState)} to be set.");
 
         this.internalState = InternalState.Transitioning;
-        await CurrentTransition.Transition(Parameters, token);
+        await currentTransition.Transition(Parameters, token);
         this.internalState = InternalState.Transitioned;
-
-        CurrentTransition = null;
     }
 
     /// <param name="methodLock">The state machine lock to release.</param>
@@ -190,8 +297,6 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         PreviousState = CurrentState;
         CurrentState = null;
         NextState = null;
-
-        CurrentTransition = null;
     }
 
     private void Rollback()
@@ -200,8 +305,6 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         NextState = null;
         CurrentState = PreviousState;
         PreviousState = null;
-
-        CurrentTransition = null;
     }
 
     /// <summary>
@@ -220,7 +323,6 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         PreviousState = null;
         CurrentState = NextState;
         NextState = null;
-        CurrentTransition = null;
         this.internalState = InternalState.Active;
 
         // Use a canceled token here so that any async work is canceled immediately; but synchronous work (or work that
@@ -246,805 +348,9 @@ internal sealed class StateMachine<TState, TTransition> : IStateMachine<TState, 
         }
     }
 
-    /// <inheritdoc />
-    public async Task Activate(CancellationToken token = default)
-    {
-        using var activationLock = await this.stateMachineLock.LockAsync(token);
-        if (this.internalState is not InternalState.Inactive)
-        {
-            throw new InvalidOperationException("The state machine has already been activated.");
-        }
-
-        try
-        {
-            await this.stateMachineActivator.Activate(this, token);
-            Debug.Assert(NextState != null, $"Expected {nameof(NextState)} to be set.");
-
-            await NextState.Activate(Parameters, token);
-            this.internalState = InternalState.Idle;
-            await ActivateTriggers(token);
-            await EnterState(activationLock, token);
-        }
-        catch when (CurrentState == null)
-        {
-            // If there was an exception during activation the state machine is forced to reset fully
-            Parameters.Clear();
-            NextState = null;
-            CurrentState = null;
-            PreviousState = null;
-
-            CurrentTransition = null;
-            this.internalState = InternalState.Inactive;
-            await DeactivateTriggers(CancellationToken.None);
-            throw;
-        }
-        catch
-        {
-            await DeactivateTriggers(CancellationToken.None);
-            throw;
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task Deactivate(CancellationToken token = default)
-    {
-        using var _ = await this.stateMachineLock.LockAsync(token);
-        if (this.internalState is InternalState.Inactive)
-        {
-            throw new InvalidOperationException("The state machine has not been activated.");
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await DeactivateTriggers(token);
-            Parameters.Clear();
-            PreviousState = null;
-            NextState = null;
-            CurrentTransition = null;
-            this.internalState = InternalState.Inactive;
-            return;
-        }
-
-        try
-        {
-            BeginTransition();
-            await ExitState(token);
-            await DeactivateTriggers(token);
-
-            await PreviousState.Deactivate(Parameters, token);
-
-            Parameters.Clear();
-            PreviousState = null;
-            this.internalState = InternalState.Inactive;
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task Transition(TTransition transition, CancellationToken token = default)
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            throw new InvalidOperationException("The state machine has not been activated.");
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetEmptyNextParameters();
-            CurrentTransition = await PreviousState.GetTransition(transition, Parameters, token);
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-    }
-
-    /// <inheritdoc />
-    public async Task Transition<T>(TTransition transition, T parameter, CancellationToken token = default)
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            throw new InvalidOperationException("The state machine has not been activated.");
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameter(parameter);
-            CurrentTransition = await PreviousState.GetTransition(transition, Parameters, token);
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-    }
-
-    /// <inheritdoc />
-    public async Task Transition<T1, T2>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        CancellationToken token = default
-    )
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            throw new InvalidOperationException("The state machine has not been activated.");
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2);
-            CurrentTransition = await PreviousState.GetTransition(transition, Parameters, token);
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-    }
-
-    /// <inheritdoc />
-    public async Task Transition<T1, T2, T3>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        T3 parameter3,
-        CancellationToken token = default
-    )
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            throw new InvalidOperationException("The state machine has not been activated.");
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2, parameter3);
-            CurrentTransition = await PreviousState.GetTransition(transition, Parameters, token);
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-    }
-
-    /// <inheritdoc />
-    public async Task Transition<T1, T2, T3, T4>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        T3 parameter3,
-        T4 parameter4,
-        CancellationToken token = default
-    )
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            throw new InvalidOperationException("The state machine has not been activated.");
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2, parameter3, parameter4);
-            CurrentTransition = await PreviousState.GetTransition(transition, Parameters, token);
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> CanTransition(TTransition transition, CancellationToken token = default)
-    {
-        using var _ = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetEmptyNextParameters();
-            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            return nextTransition != null;
-        }
-        finally
-        {
-            Rollback();
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> CanTransition<T>(TTransition transition, T parameter, CancellationToken token = default)
-    {
-        using var _ = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameter(parameter);
-            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            return nextTransition != null;
-        }
-        finally
-        {
-            Rollback();
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> CanTransition<T1, T2>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        CancellationToken token = default
-    )
-    {
-        using var _ = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2);
-            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            return nextTransition != null;
-        }
-        finally
-        {
-            Rollback();
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> CanTransition<T1, T2, T3>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        T3 parameter3,
-        CancellationToken token = default
-    )
-    {
-        using var _ = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2, parameter3);
-            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            return nextTransition != null;
-        }
-        finally
-        {
-            Rollback();
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> CanTransition<T1, T2, T3, T4>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        T3 parameter3,
-        T4 parameter4,
-        CancellationToken token = default
-    )
-    {
-        using var _ = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2, parameter3, parameter4);
-            var nextTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            return nextTransition != null;
-        }
-        finally
-        {
-            Rollback();
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryTransition(TTransition transition, CancellationToken token = default)
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetEmptyNextParameters();
-            CurrentTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            if (CurrentTransition == null)
-            {
-                Rollback();
-                return false;
-            }
-        }
-        catch
-        {
-            Rollback();
-            throw;
-        }
-
-        try
-        {
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-        return true;
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryTransition<T>(TTransition transition, T parameter, CancellationToken token = default)
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameter(parameter);
-            CurrentTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            if (CurrentTransition == null)
-            {
-                Rollback();
-                return false;
-            }
-        }
-        catch
-        {
-            Rollback();
-            throw;
-        }
-
-        try
-        {
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-        return true;
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryTransition<T1, T2>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        CancellationToken token = default
-    )
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2);
-            CurrentTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            if (CurrentTransition == null)
-            {
-                Rollback();
-                return false;
-            }
-        }
-        catch
-        {
-            Rollback();
-            throw;
-        }
-
-        try
-        {
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-        return true;
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryTransition<T1, T2, T3>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        T3 parameter3,
-        CancellationToken token = default
-    )
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2, parameter3);
-            CurrentTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            if (CurrentTransition == null)
-            {
-                Rollback();
-                return false;
-            }
-        }
-        catch
-        {
-            Rollback();
-            throw;
-        }
-
-        try
-        {
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-        return true;
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryTransition<T1, T2, T3, T4>(
-        TTransition transition,
-        T1 parameter1,
-        T2 parameter2,
-        T3 parameter3,
-        T4 parameter4,
-        CancellationToken token = default
-    )
-    {
-        using var transitionLock = await this.stateMachineLock.LockAsync(token);
-        if (
-            this.internalState is not InternalState.Active and not InternalState.Recovery and not InternalState.Entering
-        )
-        {
-            return false;
-        }
-
-        if (this.internalState is InternalState.Entering)
-        {
-            await RetryEntry(token);
-        }
-
-        try
-        {
-            BeginTransition();
-            Parameters.SetNextParameters(parameter1, parameter2, parameter3, parameter4);
-            CurrentTransition = await PreviousState.GetTransitionOrDefault(transition, Parameters, token);
-            if (CurrentTransition == null)
-            {
-                Rollback();
-                return false;
-            }
-        }
-        catch
-        {
-            Rollback();
-            throw;
-        }
-
-        try
-        {
-            NextState = CurrentTransition.Next.State;
-            await ExitState(token);
-            await Transition(token);
-        }
-        catch when (CurrentState == null)
-        {
-            Rollback();
-            this.internalState = InternalState.Recovery;
-            throw;
-        }
-
-        await EnterState(transitionLock, token);
-        return true;
-    }
-
-    /// <inheritdoc />
-    public async Task StateChange(
-        TState previousState,
-        TTransition transition,
-        TState nextState,
-        CancellationToken token
-    )
-    {
-        foreach (var onStateChange in this.onStateChanges)
-        {
-            await ExceptionBehavior.CallOnStateChange(
-                t => onStateChange.InvokeAsync(previousState, transition, nextState, t),
-                token
-            );
-        }
-    }
-
-    /// <inheritdoc />
-    public void AddState(IState<TState, TTransition> state)
-    {
-        StateTable.Add(state);
-    }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        var actionCts = this.actionCancellationTokenSource;
-
-        this.actionTask = null;
-        this.actionCancellationTokenSource = null;
-
-        actionCts?.Cancel();
-        actionCts?.Dispose();
-    }
-
     [Conditional("DEBUG")]
     private void SetupTracking()
     {
         Tracker = new DebugTracker<TState, TTransition>();
-    }
-
-    /// <summary>
-    ///     The internal state of the state machine.
-    /// </summary>
-    private enum InternalState
-    {
-        /// <summary>
-        ///     The state machine has not been activated.
-        /// </summary>
-        Inactive,
-
-        /// <summary>
-        ///     The state machine is active and ready for transitions.
-        /// </summary>
-        Active,
-
-        /// <summary>
-        ///     The state machine has completed activation and is ready to enter the next state.
-        /// </summary>
-        Idle,
-
-        /// <summary>
-        ///     The state machine is exiting a state.
-        /// </summary>
-        Exiting,
-
-        /// <summary>
-        ///     The state machine has exited the state.
-        /// </summary>
-        Exited,
-
-        /// <summary>
-        ///     The state machine is in the process of transitioning between states.
-        /// </summary>
-        Transitioning,
-
-        /// <summary>
-        ///     The state machine has transitioned: setting the next state, setting the next parameter, and has invoked
-        ///     the state change handlers. The state machine is ready to enter the next state.
-        /// </summary>
-        Transitioned,
-
-        /// <summary>
-        ///     The state machine is entering a state.
-        /// </summary>
-        Entering,
-
-        /// <summary>
-        ///     The state machine has entered the state and the state action is ready to be ran.
-        /// </summary>
-        Entered,
-
-        /// <summary>
-        ///     The state machine failed to transition. It was rolled-back to it's previous state but did not re-enter
-        ///     or restart the actions for that state.
-        /// </summary>
-        Recovery,
     }
 }

--- a/src/ZCrew.StateCraft/ZCrew.StateCraft.csproj
+++ b/src/ZCrew.StateCraft/ZCrew.StateCraft.csproj
@@ -15,4 +15,10 @@
   <ItemGroup>
     <PackageReference Include="ZCrew.Extensions.Tasks" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="StateMachines\StateMachine.*.cs">
+      <DependentUpon>StateMachine.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,49 @@
+## Test Commands
+
+```bash
+
+# Run all tests
+dotnet test
+
+# Run a specific test project
+dotnet test --project tests/ZCrew.StateCraft.UnitTests
+dotnet test --project tests/ZCrew.StateCraft.IntegrationTests
+
+# Run a single test by method name (xunit v3 with Microsoft.Testing.Platform)
+dotnet test --project tests/ZCrew.StateCraft.UnitTests --filter-method "ZCrew.StateCraft.UnitTests.StateTableTests.LookupState_WhenStateExists_ShouldReturnState"
+
+# Run tests matching a pattern (wildcards supported)
+dotnet test --project tests/ZCrew.StateCraft.UnitTests --filter-method "*LookupState*"
+
+# Run all tests in a class
+dotnet test --project tests/ZCrew.StateCraft.UnitTests --filter-class "ZCrew.StateCraft.UnitTests.StateTableTests"
+```
+
+## Testing
+
+- Test projects have `InternalsVisibleTo` access automatically via Directory.Build.props
+- Use `TestContext.Current.CancellationToken` for cancellation tokens instead of `default` or `CancellationToken.None`
+- Test names should be formatted as `Member_{T_}_When_Should` and use `{T_}` to list type parameters to distinguish tests
+- Only use `[Fact(Timeout = 5000)]` for tests with a clear deadlock risk (e.g., tests using synchronization primitives like `TaskCompletionSource`, `SemaphoreSlim`, or awaiting external signals)
+- **Avoid `Task.Delay` for synchronization** - use proper synchronization primitives:
+    - `TaskCompletionSource` to signal single events (e.g., trigger invoked, handler called)
+    - `SemaphoreSlim` for counting multiple invocations or coordinating sequences
+    - NSubstitute's `When...Do` to hook into mock invocations: `mock.When(x => x.Method()).Do(_ => tcs.TrySetResult())`
+- **CurrentState timing**: `CurrentState` is set *after* `OnEntry` handlers complete. To reliably test state transitions triggered by async operations, signal completion from within the trigger's `ThenInvoke` callback after the transition completes, not from `OnEntry`
+
+**Test Structure:**
+- Follow the AAA (Arrange-Act-Assert) pattern with blank lines separating each section
+- Add `// Arrange`, `// Act`, and `// Assert` comments to denote each section
+- Keep Act and Assert sections separate (do not combine them)
+- Create fresh instances in each test method rather than using shared fields to prevent cascading failures
+- Name the instance under test descriptively (e.g., `behavior`, `stateMachine`, `activator`) — do not use `sut`
+- Do not use `#region` blocks or decorative comment separators (e.g., `// ── Section ──────`) in any files
+- When testing that a method throws, capture the call in a named variable in the Act section, then assert on it:
+  ```csharp
+  // Act
+  var callOnEntry = () => behavior.CallOnEntry(_ => throw exception, token);
+
+  // Assert
+  await Assert.ThrowsAsync<InvalidOperationException>(callOnEntry);
+  ```
+- Use NSubstitute to assert that certain calls were made and verify call counts

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActionExceptionTests.cs
@@ -53,7 +53,6 @@ public class ActionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -167,7 +166,6 @@ public class ActionExceptionTests
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -261,7 +259,6 @@ public class ActionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -386,7 +383,6 @@ public class ActionExceptionTests
         Assert.Equal("hello", stateMachine.Parameters.GetCurrentParameter<string>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -482,7 +478,6 @@ public class ActionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -539,7 +534,6 @@ public class ActionExceptionTests
         Assert.Equal("hello", stateMachine.Parameters.GetCurrentParameter<string>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests.cs
@@ -29,7 +29,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -88,7 +87,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -146,7 +144,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T1,T2,T3,T4}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T1,T2,T3,T4}.cs
@@ -29,7 +29,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -92,7 +91,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -155,7 +153,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T1,T2,T3}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T1,T2,T3}.cs
@@ -29,7 +29,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -91,7 +90,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -149,7 +147,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T1,T2}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T1,T2}.cs
@@ -29,7 +29,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -88,7 +87,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -146,7 +144,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActivateExceptionTests{T}.cs
@@ -29,7 +29,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -89,7 +88,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -148,7 +146,6 @@ public partial class ActivateExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/DeactivateExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/DeactivateExceptionTests.cs
@@ -31,7 +31,6 @@ public class DeactivateExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -93,7 +92,6 @@ public class DeactivateExceptionTests
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -155,7 +153,6 @@ public class DeactivateExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -217,7 +214,6 @@ public class DeactivateExceptionTests
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/PendingEntryTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/PendingEntryTests.cs
@@ -30,7 +30,6 @@ public class PendingEntryTests
         Assert.Equal("hello", stateMachine.Parameters.GetNextParameter<string>());
         Assert.NotNull(stateMachine.PreviousState);
         Assert.Equal("A", stateMachine.PreviousState.StateValue);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests.cs
@@ -33,7 +33,6 @@ public class TransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -132,7 +131,6 @@ public class TransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -232,7 +230,6 @@ public class TransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -331,7 +328,6 @@ public class TransitionExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3,T4}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3,T4}.cs
@@ -36,7 +36,6 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -142,7 +141,6 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -254,7 +252,6 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -383,7 +380,6 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal((42, "hello", 3.14, true), stateMachine.Parameters.GetNextParameters<int, string, double, bool>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3}.cs
@@ -36,7 +36,6 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -142,7 +141,6 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -252,7 +250,6 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -376,7 +373,6 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Equal((42, "hello", 3.14), stateMachine.Parameters.GetNextParameters<int, string, double>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2}.cs
@@ -33,7 +33,6 @@ public class TransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -139,7 +138,6 @@ public class TransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -245,7 +243,6 @@ public class TransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -352,7 +349,6 @@ public class TransitionExceptionTests_T1_T2
         Assert.Equal((42, "hello"), stateMachine.Parameters.GetNextParameters<int, string>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T}.cs
@@ -36,7 +36,6 @@ public class TransitionExceptionTests_T
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -145,7 +144,6 @@ public class TransitionExceptionTests_T
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -251,7 +249,6 @@ public class TransitionExceptionTests_T
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -357,7 +354,6 @@ public class TransitionExceptionTests_T
         Assert.Equal("hello", stateMachine.Parameters.GetNextParameter<string>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests.cs
@@ -33,7 +33,6 @@ public class TryTransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -134,7 +133,6 @@ public class TryTransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -236,7 +234,6 @@ public class TryTransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -337,7 +334,6 @@ public class TryTransitionExceptionTests
         Assert.False(stateMachine.Parameters.IsCurrentSet);
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -403,7 +399,6 @@ public class TryTransitionExceptionTests
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3,T4}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3,T4}.cs
@@ -36,7 +36,6 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -158,7 +157,6 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -286,7 +284,6 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -431,7 +428,6 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal((42, "hello", 3.14, true), stateMachine.Parameters.GetNextParameters<int, string, double, bool>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -507,7 +503,6 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3}.cs
@@ -33,7 +33,6 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -153,7 +152,6 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -274,7 +272,6 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -410,7 +407,6 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Equal((42, "hello", true), stateMachine.Parameters.GetNextParameters<int, string, bool>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -486,7 +482,6 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2}.cs
@@ -33,7 +33,6 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -141,7 +140,6 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -249,7 +247,6 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -358,7 +355,6 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Equal((42, "hello"), stateMachine.Parameters.GetNextParameters<int, string>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -431,7 +427,6 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T}.cs
@@ -36,7 +36,6 @@ public class TryTransitionExceptionTests_T
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -147,7 +146,6 @@ public class TryTransitionExceptionTests_T
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -255,7 +253,6 @@ public class TryTransitionExceptionTests_T
         Assert.Equal(42, stateMachine.Parameters.GetCurrentParameter<int>());
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -363,7 +360,6 @@ public class TryTransitionExceptionTests_T
         Assert.Equal("hello", stateMachine.Parameters.GetNextParameter<string>());
         Assert.True(stateMachine.Parameters.IsPreviousSet);
         Assert.True(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -435,7 +431,6 @@ public class TryTransitionExceptionTests_T
         Assert.Null(stateMachine.NextState);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]
@@ -515,7 +510,6 @@ public class TryTransitionExceptionTests_T
         Assert.Null(stateMachine.NextState);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
-        Assert.Null(stateMachine.CurrentTransition);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.UnitTests/Stubs/StubStateMachine.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Stubs/StubStateMachine.cs
@@ -2,7 +2,6 @@ using ZCrew.StateCraft.Parameters;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Tracking.Contracts;
-using ZCrew.StateCraft.Transitions.Contracts;
 
 namespace ZCrew.StateCraft.UnitTests.Stubs;
 
@@ -32,8 +31,6 @@ internal class StubStateMachine<TState, TTransition> : IStateMachine<TState, TTr
     public IState<TState, TTransition>? NextState { get; set; }
 
     public IStateMachineParameters Parameters { get; } = new StateMachineParameters();
-
-    public ITransition<TState, TTransition>? CurrentTransition => null;
 
     public StateTable<TState, TTransition> StateTable { get; }
 


### PR DESCRIPTION
Cleanup the code a little, rename workflow titles, and add in `CLAUDE.md` files.

Closes #67