### PR TITLE
#88 - Improve transition error message to include current state and available transitions

### DIFF
--- a/src/ZCrew.StateCraft/States/State.cs
+++ b/src/ZCrew.StateCraft/States/State.cs
@@ -155,7 +155,17 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            throw new InvalidOperationException($"No transition could be found for: Transition={transition}");
+            var available = this.transitionTable
+                .Select(t => t.ToString())
+                .ToList();
+
+            var availableInfo = available.Count > 0
+                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                : $" No transitions registered for '{StateValue}'.";
+
+            throw new InvalidOperationException(
+                $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"
+            );
         }
         return result;
     }

--- a/src/ZCrew.StateCraft/States/State{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/State{T1,T2,T3,T4}.cs
@@ -152,7 +152,17 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            throw new InvalidOperationException($"No transition could be found for: Transition={transition}");
+            var available = this.transitionTable
+                .Select(t => t.ToString())
+                .ToList();
+
+            var availableInfo = available.Count > 0
+                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                : $" No transitions registered for '{StateValue}'.";
+
+            throw new InvalidOperationException(
+                $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"
+            );
         }
         return result;
     }

--- a/src/ZCrew.StateCraft/States/State{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/State{T1,T2,T3}.cs
@@ -151,7 +151,17 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            throw new InvalidOperationException($"No transition could be found for: Transition={transition}");
+            var available = this.transitionTable
+                .Select(t => t.ToString())
+                .ToList();
+
+            var availableInfo = available.Count > 0
+                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                : $" No transitions registered for '{StateValue}'.";
+
+            throw new InvalidOperationException(
+                $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"
+            );
         }
         return result;
     }

--- a/src/ZCrew.StateCraft/States/State{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/State{T1,T2}.cs
@@ -148,7 +148,17 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            throw new InvalidOperationException($"No transition could be found for: Transition={transition}");
+            var available = this.transitionTable
+                .Select(t => t.ToString())
+                .ToList();
+
+            var availableInfo = available.Count > 0
+                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                : $" No transitions registered for '{StateValue}'.";
+
+            throw new InvalidOperationException(
+                $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"
+            );
         }
         return result;
     }

--- a/src/ZCrew.StateCraft/States/State{T}.cs
+++ b/src/ZCrew.StateCraft/States/State{T}.cs
@@ -168,7 +168,17 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            throw new InvalidOperationException($"No transition could be found for: Transition={transition}");
+            var available = this.transitionTable
+                .Select(t => t.ToString())
+                .ToList();
+
+            var availableInfo = available.Count > 0
+                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                : $" No transitions registered for '{StateValue}'.";
+
+            throw new InvalidOperationException(
+                $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"
+            );
         }
         return result;
     }


### PR DESCRIPTION
## Summary

- Error message now includes the current state and lists all available transitions from that state
- Applied to all 5 state variants (`State`, `State<T>`, `State<T1,T2>`, `State<T1,T2,T3>`, `State<T1,T2,T3,T4>`)
- Example: `No transition could be found for 'Go' from state 'Idle'. Available from 'Idle': Go(Idle) → Active, Reset(Idle) ↩.`

**Changed:** `GetTransition()` in [`State.cs:155-161`](https://github.com/ZCrewSoftware/ZCrew.StateCraft/blob/main/src/ZCrew.StateCraft/States/State.cs#L155-L161) and all parameterized variants

Fixes #88

## Test plan

- [x] Full test suite (2778 tests pass) — no tests assert on old error text
- [x] Verified new message format includes state name and transition list

🤖 Generated with [Claude Code](https://claude.com/claude-code)