### PR TITLE
#84 - Wrap fallback mapping path in ExceptionBehavior.CallMap

### DIFF
--- a/src/ZCrew.StateCraft/Transitions/MappedTransition.cs
+++ b/src/ZCrew.StateCraft/Transitions/MappedTransition.cs
@@ -93,7 +93,10 @@ internal class MappedTransition<TState, TTransition> : ITransition<TState, TTran
 
         if (!parameters.IsNextSet)
         {
-            await this.mappingFunction.Map(parameters, token);
+            await this.stateMachine.ExceptionBehavior.CallMap(
+                t => this.mappingFunction.Map(parameters, t),
+                token
+            );
         }
         await this.stateMachine.StateChange(Previous.State.StateValue, TransitionValue, Next.State.StateValue, token);
         await Next.State.StateChange(Previous.State.StateValue, TransitionValue, parameters, token);

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/MappedTransitionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/MappedTransitionExceptionTests.cs
@@ -1,0 +1,54 @@
+using NSubstitute;
+
+namespace ZCrew.StateCraft.IntegrationTests.ExceptionHandling;
+
+public class MappedTransitionExceptionTests
+{
+    [Fact]
+    public async Task Transition_WhenMappingThrows_ShouldRouteExceptionThroughOnExceptionHandler()
+    {
+        // Arrange — the mapping function throws. This exercises the fallback
+        // mapping path in MappedTransition.Transition() which must route through
+        // ExceptionBehavior.CallMap, not bypass it.
+        var mappingException = new InvalidOperationException("Mapping failed");
+        var onException = Substitute.For<Func<Exception, ExceptionResult>>();
+        onException.Invoke(Arg.Any<Exception>()).Returns(ExceptionResult.Rethrow());
+
+        var stateMachine = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("A", 42)
+            .OnException(onException)
+            .WithState(
+                "A",
+                state =>
+                    state
+                        .WithParameter<int>()
+                        .WithTransition(
+                            "Go",
+                            t =>
+                                t.WithMappedParameter<string>(x =>
+                                    {
+                                        if (x == 42)
+                                        {
+                                            throw mappingException;
+                                        }
+
+                                        return x.ToString();
+                                    })
+                                    .To("B")
+                        )
+            )
+            .WithState("B", state => state.WithParameter<string>())
+            .Build();
+
+        await stateMachine.Activate(TestContext.Current.CancellationToken);
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => stateMachine.Transition("Go", TestContext.Current.CancellationToken)
+        );
+
+        // Assert — the exception handler must have been invoked
+        onException.Received().Invoke(mappingException);
+    }
+}


### PR DESCRIPTION
## Summary

- `MappedTransition.Transition()` had a fallback path (line 96) that called the mapping function directly, bypassing `ExceptionBehavior.CallMap`
- Now both the condition-evaluation path and the fallback path route through the exception handler pipeline consistently
- The fallback fires when `parameters.IsNextSet` is false (i.e., the transition was invoked directly via `ITransition.Transition()` rather than through the normal condition-evaluation flow)

**Changed:** [`MappedTransition.cs:94-97`](https://github.com/ZCrewSoftware/ZCrew.StateCraft/blob/main/src/ZCrew.StateCraft/Transitions/MappedTransition.cs#L94-L97)

Fixes #84

## Test plan

- [x] `Transition_WhenMappingThrows_ShouldRouteExceptionThroughOnExceptionHandler` — mapping exception invokes the registered `OnException` handler
- [x] All existing mapped transition tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)