### PR TITLE
#107 - Add regression tests for double-dispose idempotency

### DIFF
--- a/tests/ZCrew.StateCraft.UnitTests/StateMachines/DoubleDisposeTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/StateMachines/DoubleDisposeTests.cs
@@ -1,0 +1,72 @@
+namespace ZCrew.StateCraft.UnitTests.StateMachines;
+
+public class DoubleDisposeTests
+{
+    [Fact]
+    public async Task Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        // Arrange
+        var stateMachine = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("A")
+            .WithState("A", state => state)
+            .Build();
+
+        await stateMachine.Activate(TestContext.Current.CancellationToken);
+
+        // Act
+        stateMachine.Dispose();
+        var disposeAgain = () => stateMachine.Dispose();
+
+        // Assert
+        disposeAgain();
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Dispose_WhenCalledTwiceWithActiveAction_ShouldNotThrow()
+    {
+        // Arrange
+        var actionStarted = new TaskCompletionSource();
+        var stateMachine = StateMachine
+            .Configure<string, string>()
+            .WithAsynchronousActions()
+            .WithInitialState("A")
+            .WithState("A", state => state.WithAction(a => a.Invoke(Action)))
+            .Build();
+
+        await stateMachine.Activate(TestContext.Current.CancellationToken);
+        await actionStarted.Task;
+
+        // Act
+        stateMachine.Dispose();
+        var disposeAgain = () => stateMachine.Dispose();
+
+        // Assert
+        disposeAgain();
+
+        return;
+
+        async Task Action(CancellationToken token)
+        {
+            actionStarted.SetResult();
+            await Task.Delay(Timeout.Infinite, token);
+        }
+    }
+
+    [Fact]
+    public void Dispose_WhenCalledWithoutActivation_ShouldNotThrow()
+    {
+        // Arrange
+        var stateMachine = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("A")
+            .WithState("A", state => state)
+            .Build();
+
+        // Act
+        var dispose = () => stateMachine.Dispose();
+
+        // Assert
+        dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds regression tests verifying that `Dispose()` is idempotent on `StateMachine<TState, TTransition>`, as reported in #107
- Three test cases cover: activated machine disposed twice, async-action-in-flight disposed twice, and never-activated machine disposed
- The current implementation reads the CTS into a local, nulls the fields, then cancels/disposes the local — so a second call finds null fields and is a no-op. These tests lock in that behavior.

## Test plan
- [x] `Dispose_WhenCalledTwice_ShouldNotThrow` — build, activate, dispose twice, no exception
- [x] `Dispose_WhenCalledTwiceWithActiveAction_ShouldNotThrow` — async action running, dispose twice, no exception
- [x] `Dispose_WhenCalledWithoutActivation_ShouldNotThrow` — build only, dispose without activating, no exception
- [x] All 2784 existing tests pass with no regressions

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)