### PR TITLE
#99 - Change parameter type lists to ReadOnlySpan

### DIFF
--- a/src/ZCrew.StateCraft/Extensions/ReadOnlyListTypeExtensions.cs
+++ b/src/ZCrew.StateCraft/Extensions/ReadOnlyListTypeExtensions.cs
@@ -1,4 +1,4 @@
-namespace ZCrew.StateCraft;
+namespace ZCrew.StateCraft.Extensions;
 
 /// <summary>
 ///     Provides extension methods for comparing lists of <see cref="Type"/>
@@ -21,9 +21,9 @@ internal static class ReadOnlyListTypeExtensions
         ///     corresponding element in this list; otherwise,
         ///     <see langword="false"/>.
         /// </returns>
-        internal bool IsAssignableFrom(IReadOnlyList<Type> otherTypes)
+        internal bool IsAssignableFrom(ReadOnlySpan<Type> otherTypes)
         {
-            if (types.Count != otherTypes.Count)
+            if (types.Count != otherTypes.Length)
             {
                 return false;
             }

--- a/src/ZCrew.StateCraft/Parameters/Contracts/IStateMachineParameters.cs
+++ b/src/ZCrew.StateCraft/Parameters/Contracts/IStateMachineParameters.cs
@@ -31,7 +31,7 @@ internal interface IStateMachineParameters
     ///     If the <see cref="Status"/> does not indicate the
     ///     <see cref="StateMachineParametersFlags.PreviousParametersSet"/> status.
     /// </exception>
-    IReadOnlyList<Type> PreviousParameterTypes { get; }
+    ReadOnlySpan<Type> PreviousParameterTypes { get; }
 
     /// <summary>
     ///     The current type parameters, if set.
@@ -40,7 +40,7 @@ internal interface IStateMachineParameters
     ///     If the <see cref="Status"/> does not indicate the
     ///     <see cref="StateMachineParametersFlags.CurrentParametersSet"/> status.
     /// </exception>
-    IReadOnlyList<Type> CurrentParameterTypes { get; }
+    ReadOnlySpan<Type> CurrentParameterTypes { get; }
 
     /// <summary>
     ///     The next type parameters, if set.
@@ -49,7 +49,7 @@ internal interface IStateMachineParameters
     ///     If the <see cref="Status"/> does not indicate the
     ///     <see cref="StateMachineParametersFlags.NextParametersSet"/> status.
     /// </exception>
-    IReadOnlyList<Type> NextParameterTypes { get; }
+    ReadOnlySpan<Type> NextParameterTypes { get; }
 
     /// <summary>
     ///     Stages empty parameters for a parameterless transition.

--- a/src/ZCrew.StateCraft/Parameters/StateMachineParameters.cs
+++ b/src/ZCrew.StateCraft/Parameters/StateMachineParameters.cs
@@ -23,7 +23,7 @@ internal class StateMachineParameters : IStateMachineParameters
     public StateMachineParametersFlags Status { get; private set; }
 
     /// <inheritdoc />
-    public IReadOnlyList<Type> PreviousParameterTypes
+    public ReadOnlySpan<Type> PreviousParameterTypes
     {
         get
         {
@@ -32,12 +32,12 @@ internal class StateMachineParameters : IStateMachineParameters
                 throw new InvalidOperationException("Previous parameters have not been set");
             }
 
-            return this.previousParameterTypes.Take(this.previousParameterCount).OfType<Type>().ToArray();
+            return this.previousParameterTypes.AsSpan()[..this.previousParameterCount]!;
         }
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<Type> CurrentParameterTypes
+    public ReadOnlySpan<Type> CurrentParameterTypes
     {
         get
         {
@@ -46,12 +46,12 @@ internal class StateMachineParameters : IStateMachineParameters
                 throw new InvalidOperationException("Current parameters have not been set");
             }
 
-            return this.currentParameterTypes.Take(this.currentParameterCount).OfType<Type>().ToArray();
+            return this.currentParameterTypes.AsSpan()[..this.currentParameterCount]!;
         }
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<Type> NextParameterTypes
+    public ReadOnlySpan<Type> NextParameterTypes
     {
         get
         {
@@ -60,7 +60,7 @@ internal class StateMachineParameters : IStateMachineParameters
                 throw new InvalidOperationException("Next parameters have not been set");
             }
 
-            return this.nextParameterTypes.Take(this.nextParameterCount).OfType<Type>().ToArray();
+            return this.nextParameterTypes.AsSpan()[..this.nextParameterCount]!;
         }
     }
 

--- a/src/ZCrew.StateCraft/StateTable.cs
+++ b/src/ZCrew.StateCraft/StateTable.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics;
+using ZCrew.StateCraft.Extensions;
 
 namespace ZCrew.StateCraft;
 
@@ -65,18 +66,17 @@ internal sealed class StateTable<TState, TTransition> : IEnumerable<IState<TStat
             return state;
         }
 
-        var searchedDisplay = types.Length == 0
-            ? $"{stateValue}"
-            : $"{stateValue}<{string.Join(", ", types.Select(t => t.FriendlyName))}>";
+        var searchedDisplay =
+            types.Length == 0
+                ? $"{stateValue}"
+                : $"{stateValue}<{string.Join(", ", types.Select(t => t.FriendlyName))}>";
 
-        var registered = this.states
-            .Where(s => EqualityComparer<TState>.Default.Equals(s.StateValue, stateValue))
+        var registered = this
+            .states.Where(s => EqualityComparer<TState>.Default.Equals(s.StateValue, stateValue))
             .Select(s => s.ToString())
             .ToList();
 
-        var registeredInfo = registered.Count > 0
-            ? $" Registered: {string.Join(", ", registered)}."
-            : "";
+        var registeredInfo = registered.Count > 0 ? $" Registered: {string.Join(", ", registered)}." : "";
 
         throw new InvalidOperationException(
             $"No matching state could be found for: State={searchedDisplay}.{registeredInfo}"

--- a/src/ZCrew.StateCraft/TransitionTable.cs
+++ b/src/ZCrew.StateCraft/TransitionTable.cs
@@ -1,6 +1,6 @@
 using System.Collections;
 using System.Diagnostics;
-using ZCrew.StateCraft.Parameters;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.Transitions.Contracts;
 

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/ActionExceptionTests.cs
@@ -50,7 +50,7 @@ public class ActionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -256,7 +256,7 @@ public class ActionExceptionTests
         Assert.Equal("B", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -475,7 +475,7 @@ public class ActionExceptionTests
         Assert.Equal("B", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests.cs
@@ -30,7 +30,7 @@ public class CanTransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests{T1,T2,T3,T4}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests{T1,T2,T3,T4}.cs
@@ -37,7 +37,7 @@ public class CanTransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests{T1,T2,T3}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests{T1,T2,T3}.cs
@@ -37,7 +37,7 @@ public class CanTransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests{T1,T2}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/CanTransitionExceptionTests{T1,T2}.cs
@@ -37,7 +37,7 @@ public class CanTransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/DeactivateExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/DeactivateExceptionTests.cs
@@ -28,7 +28,7 @@ public class DeactivateExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -150,7 +150,7 @@ public class DeactivateExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests.cs
@@ -30,7 +30,7 @@ public class TransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -128,7 +128,7 @@ public class TransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -227,7 +227,7 @@ public class TransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3,T4}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3,T4}.cs
@@ -33,7 +33,7 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -138,7 +138,7 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -249,7 +249,7 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -450,7 +450,7 @@ public class TransitionExceptionTests_T1_T2_T3_T4
         // Assert
         Assert.NotNull(stateMachine.CurrentState);
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
         Assert.False(stateMachine.Parameters.IsPreviousSet);

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2,T3}.cs
@@ -33,7 +33,7 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -138,7 +138,7 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -247,7 +247,7 @@ public class TransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -443,7 +443,7 @@ public class TransitionExceptionTests_T1_T2_T3
         // Assert
         Assert.NotNull(stateMachine.CurrentState);
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
         Assert.False(stateMachine.Parameters.IsPreviousSet);

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TransitionExceptionTests{T1,T2}.cs
@@ -30,7 +30,7 @@ public class TransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -135,7 +135,7 @@ public class TransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -240,7 +240,7 @@ public class TransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -413,7 +413,7 @@ public class TransitionExceptionTests_T1_T2
         // Assert
         Assert.NotNull(stateMachine.CurrentState);
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
         Assert.False(stateMachine.Parameters.IsPreviousSet);

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests.cs
@@ -30,7 +30,7 @@ public class TryTransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -130,7 +130,7 @@ public class TryTransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -231,7 +231,7 @@ public class TryTransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -396,7 +396,7 @@ public class TryTransitionExceptionTests
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3,T4}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3,T4}.cs
@@ -33,7 +33,7 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -154,7 +154,7 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -281,7 +281,7 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -500,7 +500,7 @@ public class TryTransitionExceptionTests_T1_T2_T3_T4
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2,T3}.cs
@@ -30,7 +30,7 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -149,7 +149,7 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -269,7 +269,7 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -479,7 +479,7 @@ public class TryTransitionExceptionTests_T1_T2_T3
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2}.cs
+++ b/tests/ZCrew.StateCraft.IntegrationTests/ExceptionHandling/TryTransitionExceptionTests{T1,T2}.cs
@@ -30,7 +30,7 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -137,7 +137,7 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -244,7 +244,7 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }
@@ -424,7 +424,7 @@ public class TryTransitionExceptionTests_T1_T2
         Assert.Equal("A", stateMachine.CurrentState.StateValue);
         Assert.Null(stateMachine.PreviousState);
         Assert.Null(stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.CurrentParameterTypes);
+        Assert.True(stateMachine.Parameters.IsCurrentSet);
         Assert.False(stateMachine.Parameters.IsPreviousSet);
         Assert.False(stateMachine.Parameters.IsNextSet);
     }

--- a/tests/ZCrew.StateCraft.UnitTests/Parameters/StateMachineParametersTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Parameters/StateMachineParametersTests.cs
@@ -1,3 +1,4 @@
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Parameters;
 using ZCrew.StateCraft.Parameters.Contracts;
 
@@ -30,8 +31,8 @@ public class StateMachineParametersTests
 
         // Assert
         var types = parameters.NextParameterTypes;
-        Assert.Single(types);
-        Assert.Equal(typeof(string), types[0]);
+        var type = Assert.Single(types.ToArray());
+        Assert.Equal(typeof(string), type);
     }
 
     [Fact]
@@ -104,7 +105,7 @@ public class StateMachineParametersTests
 
         // Assert
         var types = parameters.NextParameterTypes;
-        Assert.Equal(2, types.Count);
+        Assert.Equal(2, types.Length);
         Assert.Equal(typeof(string), types[0]);
         Assert.Equal(typeof(int), types[1]);
     }
@@ -165,7 +166,7 @@ public class StateMachineParametersTests
 
         // Assert
         var types = parameters.NextParameterTypes;
-        Assert.Equal(3, types.Count);
+        Assert.Equal(3, types.Length);
         Assert.Equal(typeof(string), types[0]);
         Assert.Equal(typeof(int), types[1]);
         Assert.Equal(typeof(bool), types[2]);
@@ -229,7 +230,7 @@ public class StateMachineParametersTests
 
         // Assert
         var types = parameters.NextParameterTypes;
-        Assert.Equal(4, types.Count);
+        Assert.Equal(4, types.Length);
         Assert.Equal(typeof(string), types[0]);
         Assert.Equal(typeof(int), types[1]);
         Assert.Equal(typeof(bool), types[2]);
@@ -291,7 +292,7 @@ public class StateMachineParametersTests
 
         // Assert
         var types = parameters.NextParameterTypes;
-        Assert.Empty(types);
+        Assert.True(types.IsEmpty);
     }
 
     [Fact]
@@ -319,8 +320,7 @@ public class StateMachineParametersTests
         parameters.CommitTransition();
 
         // Assert
-        Assert.True(parameters.Status.HasFlag(StateMachineParametersFlags.CurrentParametersSet));
-        Assert.Empty(parameters.CurrentParameterTypes);
+        Assert.True(parameters.IsCurrentSet);
     }
 
     [Fact]
@@ -1061,7 +1061,7 @@ public class StateMachineParametersTests
 
         // Assert
         var types = parameters.CurrentParameterTypes;
-        Assert.Equal(3, types.Count);
+        Assert.Equal(3, types.Length);
         Assert.Equal(typeof(string), types[0]);
         Assert.Equal(typeof(int), types[1]);
         Assert.Equal(typeof(bool), types[2]);
@@ -1392,7 +1392,7 @@ public class StateMachineParametersTests
         var parameters = new StateMachineParameters();
 
         // Act
-        var act = () => parameters.PreviousParameterTypes;
+        var act = () => parameters.PreviousParameterTypes.ToArray();
 
         // Assert
         Assert.Throws<InvalidOperationException>(act);
@@ -1408,7 +1408,7 @@ public class StateMachineParametersTests
         parameters.BeginTransition();
 
         // Act
-        var result = parameters.PreviousParameterTypes;
+        var result = parameters.PreviousParameterTypes.ToArray();
 
         // Assert
         Assert.NotNull(result);
@@ -1421,7 +1421,7 @@ public class StateMachineParametersTests
         var parameters = new StateMachineParameters();
 
         // Act
-        var act = () => parameters.CurrentParameterTypes;
+        var act = () => parameters.CurrentParameterTypes.ToArray();
 
         // Assert
         Assert.Throws<InvalidOperationException>(act);
@@ -1436,7 +1436,7 @@ public class StateMachineParametersTests
         parameters.CommitTransition();
 
         // Act
-        var result = parameters.CurrentParameterTypes;
+        var result = parameters.CurrentParameterTypes.ToArray();
 
         // Assert
         Assert.NotNull(result);
@@ -1449,7 +1449,7 @@ public class StateMachineParametersTests
         var parameters = new StateMachineParameters();
 
         // Act
-        var act = () => parameters.NextParameterTypes;
+        var act = () => parameters.NextParameterTypes.ToArray();
 
         // Assert
         Assert.Throws<InvalidOperationException>(act);
@@ -1463,7 +1463,7 @@ public class StateMachineParametersTests
         parameters.SetNextParameter("value");
 
         // Act
-        var result = parameters.NextParameterTypes;
+        var result = parameters.NextParameterTypes.ToArray();
 
         // Assert
         Assert.NotNull(result);

--- a/tests/ZCrew.StateCraft.UnitTests/StateMachineActivatorTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/StateMachineActivatorTests.cs
@@ -1,5 +1,6 @@
 using NSubstitute;
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.UnitTests.Stubs;
 
 namespace ZCrew.StateCraft.UnitTests;
@@ -19,7 +20,7 @@ public class StateMachineActivatorTests
 
         // Assert
         Assert.Equal(expectedState, stateMachine.NextState);
-        Assert.Empty(stateMachine.Parameters.NextParameterTypes);
+        Assert.True(stateMachine.Parameters.IsNextSet);
     }
 
     [Fact]


### PR DESCRIPTION
Changes the `IReadOnlyList` to `ReadOnlySpan`. Since this is an internal property the usages were self-contained and this is non-breaking. This does still perform a slice per loop but it is now allocation-free. Spans can not cross async boundaries so this seems like a happy compromise. 

Closes #99