### PR TITLE
#106 - Add reinforcing comments about cancellation token observance

### DIFF
--- a/docs/10-triggers.md
+++ b/docs/10-triggers.md
@@ -307,7 +307,12 @@ var workAvailable = new SemaphoreSlim(0);
 ### Always Observe Cancellation Tokens
 
 Signal functions receive a cancellation token that is canceled when the state machine is deactivated.
-Pass this token to all async operations so the trigger can be interrupted cleanly:
+Pass this token to all async operations so the trigger can be interrupted cleanly.
+
+> **Warning:** Cancellation tokens **must** be observed. The token is canceled when the trigger is no longer needed
+> — either because the state machine has been deactivated or, for state-scoped triggers, because the state has
+> changed. Failing to observe the token can lead to memory leaks, deadlocks, or invalid operations where a stale
+> trigger continues to interact with the state machine after it is no longer appropriate to do so.
 
 ```csharp
 // Good: Passes cancellation token to async operations

--- a/docs/5-actions.md
+++ b/docs/5-actions.md
@@ -255,7 +255,12 @@ var machine = StateMachine
 
 ### Always Observe Cancellation Tokens
 
-This is the most important practice for actions. The cancellation token signals when to stop work:
+This is the most important practice for actions. The cancellation token signals when to stop work.
+
+> **Warning:** Cancellation tokens **must** be observed. The token is canceled when the state machine transitions
+> to a different state or is deactivated — meaning the action's work is no longer relevant. Failing to observe the
+> token can lead to memory leaks, deadlocks, or invalid operations where a stale action continues to interact with
+> the state machine after the state has already changed.
 
 ```csharp
 // Good: Respects cancellation throughout

--- a/src/ZCrew.StateCraft/StateMachines/Configuration/IStateMachineConfiguration.cs
+++ b/src/ZCrew.StateCraft/StateMachines/Configuration/IStateMachineConfiguration.cs
@@ -1,6 +1,5 @@
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.StateMachines.Contracts;
-using ZCrew.StateCraft.Validation.Models;
 
 namespace ZCrew.StateCraft;
 
@@ -31,6 +30,13 @@ public interface IStateMachineConfiguration<TState, TTransition>
     ///     without awaiting the completion of the action. Without this option the transition will await the completion
     ///     of the action, which may incur delays if the action is long-running.
     /// </summary>
+    /// <remarks>
+    ///     Asynchronous actions receive a <see cref="CancellationToken"/> that is canceled when the state
+    ///     machine transitions to a different state or is deactivated. Actions <b>must</b> observe this
+    ///     token — once canceled, the action's work is no longer relevant. Failing to observe it can lead
+    ///     to memory leaks, deadlocks, or invalid operations where a stale action continues to interact
+    ///     with the state machine after the state has already changed.
+    /// </remarks>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     /// <example>
     /// <code>


### PR DESCRIPTION
Adds comments about observing `CancellationToken` with asynchronous actions and triggers.

Closes #106