### PR TITLE
#155 - Swap out func of bools and actions with conditions and handlers

### DIFF
--- a/src/ZCrew.StateCraft/Async/AsyncCondition.cs
+++ b/src/ZCrew.StateCraft/Async/AsyncCondition.cs
@@ -1,0 +1,133 @@
+using ZCrew.Extensions.Tasks;
+
+namespace ZCrew.StateCraft.Async;
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncFunc{Boolean}"/> that represents a parameterless
+///     asynchronous predicate evaluated by the state machine.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give conditions a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with conditions in the future without changing call sites.
+/// </remarks>
+/// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
+internal readonly record struct AsyncCondition(IAsyncFunc<bool> Condition)
+{
+    /// <summary>
+    ///     Evaluates the wrapped condition.
+    /// </summary>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that resolves to the boolean result of the condition.</returns>
+    public Task<bool> Evaluate(CancellationToken token)
+    {
+        return Condition.InvokeAsync(token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncFunc{T, Boolean}"/> that represents an asynchronous
+///     predicate accepting a single parameter.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give conditions a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with conditions in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T">The type of the parameter passed to the condition.</typeparam>
+/// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
+internal readonly record struct AsyncCondition<T>(IAsyncFunc<T, bool> Condition)
+{
+    /// <summary>
+    ///     Evaluates the wrapped condition with the provided parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter forwarded to the condition.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that resolves to the boolean result of the condition.</returns>
+    public Task<bool> Evaluate(T parameter, CancellationToken token)
+    {
+        return Condition.InvokeAsync(parameter, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncFunc{T1, T2, Boolean}"/> that represents an asynchronous
+///     predicate accepting two parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give conditions a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with conditions in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the condition.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the condition.</typeparam>
+/// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
+internal readonly record struct AsyncCondition<T1, T2>(IAsyncFunc<T1, T2, bool> Condition)
+{
+    /// <summary>
+    ///     Evaluates the wrapped condition with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the condition.</param>
+    /// <param name="parameter2">The second parameter forwarded to the condition.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that resolves to the boolean result of the condition.</returns>
+    public Task<bool> Evaluate(T1 parameter1, T2 parameter2, CancellationToken token)
+    {
+        return Condition.InvokeAsync(parameter1, parameter2, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncFunc{T1, T2, T3, Boolean}"/> that represents an
+///     asynchronous predicate accepting three parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give conditions a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with conditions in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the condition.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the condition.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the condition.</typeparam>
+/// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
+internal readonly record struct AsyncCondition<T1, T2, T3>(IAsyncFunc<T1, T2, T3, bool> Condition)
+{
+    /// <summary>
+    ///     Evaluates the wrapped condition with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the condition.</param>
+    /// <param name="parameter2">The second parameter forwarded to the condition.</param>
+    /// <param name="parameter3">The third parameter forwarded to the condition.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that resolves to the boolean result of the condition.</returns>
+    public Task<bool> Evaluate(T1 parameter1, T2 parameter2, T3 parameter3, CancellationToken token)
+    {
+        return Condition.InvokeAsync(parameter1, parameter2, parameter3, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncFunc{T1, T2, T3, T4, Boolean}"/> that represents an
+///     asynchronous predicate accepting four parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give conditions a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with conditions in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the condition.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the condition.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the condition.</typeparam>
+/// <typeparam name="T4">The type of the fourth parameter passed to the condition.</typeparam>
+/// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
+internal readonly record struct AsyncCondition<T1, T2, T3, T4>(IAsyncFunc<T1, T2, T3, T4, bool> Condition)
+{
+    /// <summary>
+    ///     Evaluates the wrapped condition with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the condition.</param>
+    /// <param name="parameter2">The second parameter forwarded to the condition.</param>
+    /// <param name="parameter3">The third parameter forwarded to the condition.</param>
+    /// <param name="parameter4">The fourth parameter forwarded to the condition.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that resolves to the boolean result of the condition.</returns>
+    public Task<bool> Evaluate(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4, CancellationToken token)
+    {
+        return Condition.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
+    }
+}

--- a/src/ZCrew.StateCraft/Async/AsyncHandler.cs
+++ b/src/ZCrew.StateCraft/Async/AsyncHandler.cs
@@ -1,0 +1,330 @@
+using ZCrew.Extensions.Tasks;
+
+namespace ZCrew.StateCraft.Async;
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction"/> that represents a parameterless asynchronous
+///     handler invoked by the state machine.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler(IAsyncAction Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler.
+    /// </summary>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(CancellationToken token)
+    {
+        return Handler.InvokeAsync(token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T}"/> that represents an asynchronous handler
+///     accepting a single parameter.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T">The type of the parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T>(IAsyncAction<T> Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameter.
+    /// </summary>
+    /// <param name="parameter">The parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(T parameter, CancellationToken token)
+    {
+        return Handler.InvokeAsync(parameter, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2}"/> that represents an asynchronous handler
+///     accepting two parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2>(IAsyncAction<T1, T2> Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(T1 parameter1, T2 parameter2, CancellationToken token)
+    {
+        return Handler.InvokeAsync(parameter1, parameter2, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2, T3}"/> that represents an asynchronous
+///     handler accepting three parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3>(IAsyncAction<T1, T2, T3> Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="parameter3">The third parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(T1 parameter1, T2 parameter2, T3 parameter3, CancellationToken token)
+    {
+        return Handler.InvokeAsync(parameter1, parameter2, parameter3, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2, T3, T4}"/> that represents an asynchronous
+///     handler accepting four parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
+/// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4>(IAsyncAction<T1, T2, T3, T4> Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="parameter3">The third parameter forwarded to the handler.</param>
+    /// <param name="parameter4">The fourth parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4, CancellationToken token)
+    {
+        return Handler.InvokeAsync(parameter1, parameter2, parameter3, parameter4, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2, T3, T4, T5}"/> that represents an
+///     asynchronous handler accepting five parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
+/// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
+/// <typeparam name="T5">The type of the fifth parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5>(IAsyncAction<T1, T2, T3, T4, T5> Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="parameter3">The third parameter forwarded to the handler.</param>
+    /// <param name="parameter4">The fourth parameter forwarded to the handler.</param>
+    /// <param name="parameter5">The fifth parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        T5 parameter5,
+        CancellationToken token
+    )
+    {
+        return Handler.InvokeAsync(parameter1, parameter2, parameter3, parameter4, parameter5, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2, T3, T4, T5, T6}"/> that represents an
+///     asynchronous handler accepting six parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
+/// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
+/// <typeparam name="T5">The type of the fifth parameter passed to the handler.</typeparam>
+/// <typeparam name="T6">The type of the sixth parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6>(IAsyncAction<T1, T2, T3, T4, T5, T6> Handler)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="parameter3">The third parameter forwarded to the handler.</param>
+    /// <param name="parameter4">The fourth parameter forwarded to the handler.</param>
+    /// <param name="parameter5">The fifth parameter forwarded to the handler.</param>
+    /// <param name="parameter6">The sixth parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        T5 parameter5,
+        T6 parameter6,
+        CancellationToken token
+    )
+    {
+        return Handler.InvokeAsync(parameter1, parameter2, parameter3, parameter4, parameter5, parameter6, token);
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2, T3, T4, T5, T6, T7}"/> that represents an
+///     asynchronous handler accepting seven parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
+/// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
+/// <typeparam name="T5">The type of the fifth parameter passed to the handler.</typeparam>
+/// <typeparam name="T6">The type of the sixth parameter passed to the handler.</typeparam>
+/// <typeparam name="T7">The type of the seventh parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6, T7>(
+    IAsyncAction<T1, T2, T3, T4, T5, T6, T7> Handler
+)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="parameter3">The third parameter forwarded to the handler.</param>
+    /// <param name="parameter4">The fourth parameter forwarded to the handler.</param>
+    /// <param name="parameter5">The fifth parameter forwarded to the handler.</param>
+    /// <param name="parameter6">The sixth parameter forwarded to the handler.</param>
+    /// <param name="parameter7">The seventh parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        T5 parameter5,
+        T6 parameter6,
+        T7 parameter7,
+        CancellationToken token
+    )
+    {
+        return Handler.InvokeAsync(
+            parameter1,
+            parameter2,
+            parameter3,
+            parameter4,
+            parameter5,
+            parameter6,
+            parameter7,
+            token
+        );
+    }
+}
+
+/// <summary>
+///     A strongly-typed wrapper around an <see cref="IAsyncAction{T1, T2, T3, T4, T5, T6, T7, T8}"/> that represents
+///     an asynchronous handler accepting eight parameters.
+/// </summary>
+/// <remarks>
+///     This wrapper exists to give handlers a distinct nominal type rather than relying on bare delegate types,
+///     which allows additional metadata to be associated with handlers in the future without changing call sites.
+/// </remarks>
+/// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
+/// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
+/// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
+/// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
+/// <typeparam name="T5">The type of the fifth parameter passed to the handler.</typeparam>
+/// <typeparam name="T6">The type of the sixth parameter passed to the handler.</typeparam>
+/// <typeparam name="T7">The type of the seventh parameter passed to the handler.</typeparam>
+/// <typeparam name="T8">The type of the eighth parameter passed to the handler.</typeparam>
+/// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(
+    IAsyncAction<T1, T2, T3, T4, T5, T6, T7, T8> Handler
+)
+{
+    /// <summary>
+    ///     Invokes the wrapped handler with the provided parameters.
+    /// </summary>
+    /// <param name="parameter1">The first parameter forwarded to the handler.</param>
+    /// <param name="parameter2">The second parameter forwarded to the handler.</param>
+    /// <param name="parameter3">The third parameter forwarded to the handler.</param>
+    /// <param name="parameter4">The fourth parameter forwarded to the handler.</param>
+    /// <param name="parameter5">The fifth parameter forwarded to the handler.</param>
+    /// <param name="parameter6">The sixth parameter forwarded to the handler.</param>
+    /// <param name="parameter7">The seventh parameter forwarded to the handler.</param>
+    /// <param name="parameter8">The eighth parameter forwarded to the handler.</param>
+    /// <param name="token">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that completes when the handler finishes executing.</returns>
+    public Task Invoke(
+        T1 parameter1,
+        T2 parameter2,
+        T3 parameter3,
+        T4 parameter4,
+        T5 parameter5,
+        T6 parameter6,
+        T7 parameter7,
+        T8 parameter8,
+        CancellationToken token
+    )
+    {
+        return Handler.InvokeAsync(
+            parameter1,
+            parameter2,
+            parameter3,
+            parameter4,
+            parameter5,
+            parameter6,
+            parameter7,
+            parameter8,
+            token
+        );
+    }
+}

--- a/src/ZCrew.StateCraft/Extensions/AsyncActionExtensions.cs
+++ b/src/ZCrew.StateCraft/Extensions/AsyncActionExtensions.cs
@@ -1,0 +1,162 @@
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
+
+namespace ZCrew.StateCraft.Extensions;
+
+/// <summary>
+///     Extension methods for converting <see cref="IAsyncAction"/> instances and their parameterized counterparts
+///     into the strongly-typed <see cref="AsyncHandler"/> wrapper types.
+/// </summary>
+/// <remarks>
+///     These conversions exist so that the state machine can work with a distinct handler type rather than a bare
+///     action delegate, allowing future metadata to be attached to handlers without changing call sites.
+/// </remarks>
+internal static class AsyncActionExtensions
+{
+    /// <summary>
+    ///     Wraps a parameterless asynchronous action as an <see cref="AsyncHandler"/>.
+    /// </summary>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>An <see cref="AsyncHandler"/> that delegates invocation to <paramref name="action"/>.</returns>
+    public static AsyncHandler AsAsyncHandler(this IAsyncAction action)
+    {
+        return new AsyncHandler(action);
+    }
+
+    /// <summary>
+    ///     Wraps a single-parameter asynchronous action as an <see cref="AsyncHandler{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>An <see cref="AsyncHandler{T}"/> that delegates invocation to <paramref name="action"/>.</returns>
+    public static AsyncHandler<T> AsAsyncHandler<T>(this IAsyncAction<T> action)
+    {
+        return new AsyncHandler<T>(action);
+    }
+
+    /// <summary>
+    ///     Wraps a two-parameter asynchronous action as an <see cref="AsyncHandler{T1, T2}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>An <see cref="AsyncHandler{T1, T2}"/> that delegates invocation to <paramref name="action"/>.</returns>
+    public static AsyncHandler<T1, T2> AsAsyncHandler<T1, T2>(this IAsyncAction<T1, T2> action)
+    {
+        return new AsyncHandler<T1, T2>(action);
+    }
+
+    /// <summary>
+    ///     Wraps a three-parameter asynchronous action as an <see cref="AsyncHandler{T1, T2, T3}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>An <see cref="AsyncHandler{T1, T2, T3}"/> that delegates invocation to <paramref name="action"/>.</returns>
+    public static AsyncHandler<T1, T2, T3> AsAsyncHandler<T1, T2, T3>(this IAsyncAction<T1, T2, T3> action)
+    {
+        return new AsyncHandler<T1, T2, T3>(action);
+    }
+
+    /// <summary>
+    ///     Wraps a four-parameter asynchronous action as an <see cref="AsyncHandler{T1, T2, T3, T4}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>
+    ///     An <see cref="AsyncHandler{T1, T2, T3, T4}"/> that delegates invocation to <paramref name="action"/>.
+    /// </returns>
+    public static AsyncHandler<T1, T2, T3, T4> AsAsyncHandler<T1, T2, T3, T4>(this IAsyncAction<T1, T2, T3, T4> action)
+    {
+        return new AsyncHandler<T1, T2, T3, T4>(action);
+    }
+
+    /// <summary>
+    ///     Wraps a five-parameter asynchronous action as an <see cref="AsyncHandler{T1, T2, T3, T4, T5}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
+    /// <typeparam name="T5">The type of the fifth parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>
+    ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5}"/> that delegates invocation to <paramref name="action"/>.
+    /// </returns>
+    public static AsyncHandler<T1, T2, T3, T4, T5> AsAsyncHandler<T1, T2, T3, T4, T5>(
+        this IAsyncAction<T1, T2, T3, T4, T5> action
+    )
+    {
+        return new AsyncHandler<T1, T2, T3, T4, T5>(action);
+    }
+
+    /// <summary>
+    ///     Wraps a six-parameter asynchronous action as an <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
+    /// <typeparam name="T5">The type of the fifth parameter passed to the action.</typeparam>
+    /// <typeparam name="T6">The type of the sixth parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>
+    ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6}"/> that delegates invocation to <paramref name="action"/>.
+    /// </returns>
+    public static AsyncHandler<T1, T2, T3, T4, T5, T6> AsAsyncHandler<T1, T2, T3, T4, T5, T6>(
+        this IAsyncAction<T1, T2, T3, T4, T5, T6> action
+    )
+    {
+        return new AsyncHandler<T1, T2, T3, T4, T5, T6>(action);
+    }
+
+    /// <summary>
+    ///     Wraps a seven-parameter asynchronous action as an <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6, T7}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
+    /// <typeparam name="T5">The type of the fifth parameter passed to the action.</typeparam>
+    /// <typeparam name="T6">The type of the sixth parameter passed to the action.</typeparam>
+    /// <typeparam name="T7">The type of the seventh parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>
+    ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6, T7}"/> that delegates invocation to
+    ///     <paramref name="action"/>.
+    /// </returns>
+    public static AsyncHandler<T1, T2, T3, T4, T5, T6, T7> AsAsyncHandler<T1, T2, T3, T4, T5, T6, T7>(
+        this IAsyncAction<T1, T2, T3, T4, T5, T6, T7> action
+    )
+    {
+        return new AsyncHandler<T1, T2, T3, T4, T5, T6, T7>(action);
+    }
+
+    /// <summary>
+    ///     Wraps an eight-parameter asynchronous action as an
+    ///     <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6, T7, T8}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
+    /// <typeparam name="T5">The type of the fifth parameter passed to the action.</typeparam>
+    /// <typeparam name="T6">The type of the sixth parameter passed to the action.</typeparam>
+    /// <typeparam name="T7">The type of the seventh parameter passed to the action.</typeparam>
+    /// <typeparam name="T8">The type of the eighth parameter passed to the action.</typeparam>
+    /// <param name="action">The asynchronous action to wrap.</param>
+    /// <returns>
+    ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6, T7, T8}"/> that delegates invocation to
+    ///     <paramref name="action"/>.
+    /// </returns>
+    public static AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8> AsAsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(
+        this IAsyncAction<T1, T2, T3, T4, T5, T6, T7, T8> action
+    )
+    {
+        return new AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(action);
+    }
+}

--- a/src/ZCrew.StateCraft/Extensions/AsyncFuncExtensions.cs
+++ b/src/ZCrew.StateCraft/Extensions/AsyncFuncExtensions.cs
@@ -1,0 +1,79 @@
+using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
+
+namespace ZCrew.StateCraft.Extensions;
+
+/// <summary>
+///     Extension methods for converting <see cref="IAsyncFunc{Boolean}"/> instances and their parameterized
+///     counterparts into the strongly-typed <see cref="AsyncCondition"/> wrapper types.
+/// </summary>
+/// <remarks>
+///     These conversions exist so that the state machine can work with a distinct condition type rather than a bare
+///     boolean-returning delegate, allowing future metadata to be attached to conditions without changing call sites.
+/// </remarks>
+internal static class AsyncFuncExtensions
+{
+    /// <summary>
+    ///     Wraps a parameterless asynchronous predicate as an <see cref="AsyncCondition"/>.
+    /// </summary>
+    /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <returns>An <see cref="AsyncCondition"/> that delegates evaluation to <paramref name="func"/>.</returns>
+    public static AsyncCondition AsAsyncCondition(this IAsyncFunc<bool> func)
+    {
+        return new AsyncCondition(func);
+    }
+
+    /// <summary>
+    ///     Wraps a single-parameter asynchronous predicate as an <see cref="AsyncCondition{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter passed to the predicate.</typeparam>
+    /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <returns>An <see cref="AsyncCondition{T}"/> that delegates evaluation to <paramref name="func"/>.</returns>
+    public static AsyncCondition<T> AsAsyncCondition<T>(this IAsyncFunc<T, bool> func)
+    {
+        return new AsyncCondition<T>(func);
+    }
+
+    /// <summary>
+    ///     Wraps a two-parameter asynchronous predicate as an <see cref="AsyncCondition{T1, T2}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the predicate.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the predicate.</typeparam>
+    /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <returns>An <see cref="AsyncCondition{T1, T2}"/> that delegates evaluation to <paramref name="func"/>.</returns>
+    public static AsyncCondition<T1, T2> AsAsyncCondition<T1, T2>(this IAsyncFunc<T1, T2, bool> func)
+    {
+        return new AsyncCondition<T1, T2>(func);
+    }
+
+    /// <summary>
+    ///     Wraps a three-parameter asynchronous predicate as an <see cref="AsyncCondition{T1, T2, T3}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the predicate.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the predicate.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the predicate.</typeparam>
+    /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <returns>An <see cref="AsyncCondition{T1, T2, T3}"/> that delegates evaluation to <paramref name="func"/>.</returns>
+    public static AsyncCondition<T1, T2, T3> AsAsyncCondition<T1, T2, T3>(this IAsyncFunc<T1, T2, T3, bool> func)
+    {
+        return new AsyncCondition<T1, T2, T3>(func);
+    }
+
+    /// <summary>
+    ///     Wraps a four-parameter asynchronous predicate as an <see cref="AsyncCondition{T1, T2, T3, T4}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first parameter passed to the predicate.</typeparam>
+    /// <typeparam name="T2">The type of the second parameter passed to the predicate.</typeparam>
+    /// <typeparam name="T3">The type of the third parameter passed to the predicate.</typeparam>
+    /// <typeparam name="T4">The type of the fourth parameter passed to the predicate.</typeparam>
+    /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <returns>
+    ///     An <see cref="AsyncCondition{T1, T2, T3, T4}"/> that delegates evaluation to <paramref name="func"/>.
+    /// </returns>
+    public static AsyncCondition<T1, T2, T3, T4> AsAsyncCondition<T1, T2, T3, T4>(
+        this IAsyncFunc<T1, T2, T3, T4, bool> func
+    )
+    {
+        return new AsyncCondition<T1, T2, T3, T4>(func);
+    }
+}

--- a/src/ZCrew.StateCraft/States/Configuration/IPartialNextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IPartialNextStateConfiguration.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 
 namespace ZCrew.StateCraft.States.Configuration;
 
@@ -21,7 +21,7 @@ internal interface IPartialNextStateConfiguration<TState, TTransition>
     ///     Adds a parameterless condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<bool> condition);
+    void Add(AsyncCondition condition);
 
     /// <summary>
     ///     Completes the partial configuration by specifying the target state, producing a full
@@ -52,7 +52,7 @@ internal interface IPartialNextStateConfiguration<TState, TTransition, T>
     ///     Adds a single-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T, bool> condition);
+    void Add(AsyncCondition<T> condition);
 
     /// <summary>
     ///     Completes the partial configuration by specifying the target state, producing a full
@@ -84,7 +84,7 @@ internal interface IPartialNextStateConfiguration<TState, TTransition, T1, T2>
     ///     Adds a two-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T1, T2, bool> condition);
+    void Add(AsyncCondition<T1, T2> condition);
 
     /// <summary>
     ///     Completes the partial configuration by specifying the target state, producing a full
@@ -117,7 +117,7 @@ internal interface IPartialNextStateConfiguration<TState, TTransition, T1, T2, T
     ///     Adds a three-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T1, T2, T3, bool> condition);
+    void Add(AsyncCondition<T1, T2, T3> condition);
 
     /// <summary>
     ///     Completes the partial configuration by specifying the target state, producing a full
@@ -151,7 +151,7 @@ internal interface IPartialNextStateConfiguration<TState, TTransition, T1, T2, T
     ///     Adds a four-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T1, T2, T3, T4, bool> condition);
+    void Add(AsyncCondition<T1, T2, T3, T4> condition);
 
     /// <summary>
     ///     Completes the partial configuration by specifying the target state, producing a full

--- a/src/ZCrew.StateCraft/States/Configuration/IPartialPreviousStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IPartialPreviousStateConfiguration.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 
 namespace ZCrew.StateCraft.States.Configuration;
 
@@ -23,7 +23,7 @@ internal interface IPartialPreviousStateConfiguration<TState, TTransition>
     ///     Adds a parameterless condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<bool> condition);
+    void Add(AsyncCondition condition);
 }
 
 /// <summary>
@@ -48,7 +48,7 @@ internal interface IPartialPreviousStateConfiguration<TState, TTransition, T>
     ///     Adds a single-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T, bool> condition);
+    void Add(AsyncCondition<T> condition);
 }
 
 /// <summary>
@@ -74,7 +74,7 @@ internal interface IPartialPreviousStateConfiguration<TState, TTransition, T1, T
     ///     Adds a two-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T1, T2, bool> condition);
+    void Add(AsyncCondition<T1, T2> condition);
 }
 
 /// <summary>
@@ -101,7 +101,7 @@ internal interface IPartialPreviousStateConfiguration<TState, TTransition, T1, T
     ///     Adds a three-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T1, T2, T3, bool> condition);
+    void Add(AsyncCondition<T1, T2, T3> condition);
 }
 
 /// <summary>
@@ -129,5 +129,5 @@ internal interface IPartialPreviousStateConfiguration<TState, TTransition, T1, T
     ///     Adds a four-parameter condition that must be satisfied for the transition to proceed.
     /// </summary>
     /// <param name="condition">The condition to add.</param>
-    void Add(IAsyncFunc<T1, T2, T3, T4, bool> condition);
+    void Add(AsyncCondition<T1, T2, T3, T4> condition);
 }

--- a/src/ZCrew.StateCraft/States/NextState.cs
+++ b/src/ZCrew.StateCraft/States/NextState.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.States.Contracts;
 
@@ -19,14 +19,14 @@ internal class NextState<TState, TTransition> : INextState<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="NextState{TState, TTransition}"/> class.
     /// </summary>
     /// <param name="state">The state that this next state references.</param>
     /// <param name="conditions">The conditions that must be satisfied before transitioning.</param>
-    public NextState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<bool>> conditions)
+    public NextState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -43,7 +43,7 @@ internal class NextState<TState, TTransition> : INextState<TState, TTransition>
     {
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(token);
+            var result = await condition.Evaluate(token);
             if (!result)
             {
                 return false;
@@ -76,14 +76,14 @@ internal class NextState<TState, TTransition, T> : INextState<TState, TTransitio
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="NextState{TState, TTransition, T}"/> class.
     /// </summary>
     /// <param name="state">The state that this next state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T, bool>> conditions)
+    public NextState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -106,7 +106,7 @@ internal class NextState<TState, TTransition, T> : INextState<TState, TTransitio
         var parameter = parameters.GetNextParameter<T>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(parameter, token);
+            var result = await condition.Evaluate(parameter, token);
             if (!result)
             {
                 return false;
@@ -140,14 +140,14 @@ internal class NextState<TState, TTransition, T1, T2> : INextState<TState, TTran
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="NextState{TState, TTransition, T1, T2}"/> class.
     /// </summary>
     /// <param name="state">The state that this next state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T1, T2, bool>> conditions)
+    public NextState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T1, T2>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -170,7 +170,7 @@ internal class NextState<TState, TTransition, T1, T2> : INextState<TState, TTran
         var (p1, p2) = parameters.GetNextParameters<T1, T2>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(p1, p2, token);
+            var result = await condition.Evaluate(p1, p2, token);
             if (!result)
             {
                 return false;
@@ -205,7 +205,7 @@ internal class NextState<TState, TTransition, T1, T2, T3> : INextState<TState, T
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, T3, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2, T3>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -213,7 +213,7 @@ internal class NextState<TState, TTransition, T1, T2, T3> : INextState<TState, T
     /// </summary>
     /// <param name="state">The state that this next state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T1, T2, T3, bool>> conditions)
+    public NextState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T1, T2, T3>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -236,7 +236,7 @@ internal class NextState<TState, TTransition, T1, T2, T3> : INextState<TState, T
         var (p1, p2, p3) = parameters.GetNextParameters<T1, T2, T3>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(p1, p2, p3, token);
+            var result = await condition.Evaluate(p1, p2, p3, token);
             if (!result)
             {
                 return false;
@@ -272,7 +272,7 @@ internal class NextState<TState, TTransition, T1, T2, T3, T4> : INextState<TStat
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, T3, T4, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2, T3, T4>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -280,7 +280,7 @@ internal class NextState<TState, TTransition, T1, T2, T3, T4> : INextState<TStat
     /// </summary>
     /// <param name="state">The state that this next state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T1, T2, T3, T4, bool>> conditions)
+    public NextState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T1, T2, T3, T4>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -303,7 +303,7 @@ internal class NextState<TState, TTransition, T1, T2, T3, T4> : INextState<TStat
         var (p1, p2, p3, p4) = parameters.GetNextParameters<T1, T2, T3, T4>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(p1, p2, p3, p4, token);
+            var result = await condition.Evaluate(p1, p2, p3, p4, token);
             if (!result)
             {
                 return false;

--- a/src/ZCrew.StateCraft/States/NextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/NextStateConfiguration.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.States.Configuration;
 using ZCrew.StateCraft.States.Contracts;
 
@@ -20,14 +20,14 @@ internal class NextStateConfiguration<TState, TTransition> : INextStateConfigura
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="NextStateConfiguration{TState, TTransition}"/> class.
     /// </summary>
     /// <param name="stateValue">The target state value.</param>
     /// <param name="conditions">The conditions that must be satisfied before transitioning.</param>
-    public NextStateConfiguration(TState stateValue, IReadOnlyList<IAsyncFunc<bool>> conditions)
+    public NextStateConfiguration(TState stateValue, IReadOnlyList<AsyncCondition> conditions)
     {
         StateValue = stateValue;
         this.conditions = conditions;
@@ -73,14 +73,14 @@ internal class NextStateConfiguration<TState, TTransition, T> : INextStateConfig
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="NextStateConfiguration{TState, TTransition, T}"/> class.
     /// </summary>
     /// <param name="stateValue">The target state value.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextStateConfiguration(TState stateValue, IReadOnlyList<IAsyncFunc<T, bool>> conditions)
+    public NextStateConfiguration(TState stateValue, IReadOnlyList<AsyncCondition<T>> conditions)
     {
         StateValue = stateValue;
         this.conditions = conditions;
@@ -127,7 +127,7 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2> : INextStateC
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -135,7 +135,7 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2> : INextStateC
     /// </summary>
     /// <param name="stateValue">The target state value.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextStateConfiguration(TState stateValue, IReadOnlyList<IAsyncFunc<T1, T2, bool>> conditions)
+    public NextStateConfiguration(TState stateValue, IReadOnlyList<AsyncCondition<T1, T2>> conditions)
     {
         StateValue = stateValue;
         this.conditions = conditions;
@@ -183,7 +183,7 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3> : INextSt
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, T3, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2, T3>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -191,7 +191,7 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3> : INextSt
     /// </summary>
     /// <param name="stateValue">The target state value.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextStateConfiguration(TState stateValue, IReadOnlyList<IAsyncFunc<T1, T2, T3, bool>> conditions)
+    public NextStateConfiguration(TState stateValue, IReadOnlyList<AsyncCondition<T1, T2, T3>> conditions)
     {
         StateValue = stateValue;
         this.conditions = conditions;
@@ -241,7 +241,7 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3, T4>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, T3, T4, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2, T3, T4>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -249,7 +249,7 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3, T4>
     /// </summary>
     /// <param name="stateValue">The target state value.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public NextStateConfiguration(TState stateValue, IReadOnlyList<IAsyncFunc<T1, T2, T3, T4, bool>> conditions)
+    public NextStateConfiguration(TState stateValue, IReadOnlyList<AsyncCondition<T1, T2, T3, T4>> conditions)
     {
         StateValue = stateValue;
         this.conditions = conditions;

--- a/src/ZCrew.StateCraft/States/PartialNextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/PartialNextStateConfiguration.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.States.Configuration;
 
 namespace ZCrew.StateCraft.States;
@@ -18,10 +18,10 @@ internal class PartialNextStateConfiguration<TState, TTransition> : IPartialNext
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<bool>> conditions = [];
+    private readonly List<AsyncCondition> conditions = [];
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<bool> condition)
+    public void Add(AsyncCondition condition)
     {
         this.conditions.Add(condition);
     }
@@ -56,10 +56,10 @@ internal class PartialNextStateConfiguration<TState, TTransition, T>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T, bool>> conditions = [];
+    private readonly List<AsyncCondition<T>> conditions = [];
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T, bool> condition)
+    public void Add(AsyncCondition<T> condition)
     {
         this.conditions.Add(condition);
     }
@@ -95,10 +95,10 @@ internal class PartialNextStateConfiguration<TState, TTransition, T1, T2>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T1, T2, bool>> conditions = [];
+    private readonly List<AsyncCondition<T1, T2>> conditions = [];
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T1, T2, bool> condition)
+    public void Add(AsyncCondition<T1, T2> condition)
     {
         this.conditions.Add(condition);
     }
@@ -135,10 +135,10 @@ internal class PartialNextStateConfiguration<TState, TTransition, T1, T2, T3>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T1, T2, T3, bool>> conditions = [];
+    private readonly List<AsyncCondition<T1, T2, T3>> conditions = [];
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T1, T2, T3, bool> condition)
+    public void Add(AsyncCondition<T1, T2, T3> condition)
     {
         this.conditions.Add(condition);
     }
@@ -176,10 +176,10 @@ internal class PartialNextStateConfiguration<TState, TTransition, T1, T2, T3, T4
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T1, T2, T3, T4, bool>> conditions = [];
+    private readonly List<AsyncCondition<T1, T2, T3, T4>> conditions = [];
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T1, T2, T3, T4, bool> condition)
+    public void Add(AsyncCondition<T1, T2, T3, T4> condition)
     {
         this.conditions.Add(condition);
     }

--- a/src/ZCrew.StateCraft/States/PreviousState.cs
+++ b/src/ZCrew.StateCraft/States/PreviousState.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.States.Contracts;
 
@@ -19,14 +19,14 @@ internal class PreviousState<TState, TTransition> : IPreviousState<TState, TTran
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PreviousState{TState, TTransition}"/> class.
     /// </summary>
     /// <param name="state">The state that this previous state references.</param>
     /// <param name="conditions">The conditions that must be satisfied before transitioning.</param>
-    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<bool>> conditions)
+    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -43,7 +43,7 @@ internal class PreviousState<TState, TTransition> : IPreviousState<TState, TTran
     {
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(token);
+            var result = await condition.Evaluate(token);
             if (!result)
             {
                 return false;
@@ -76,14 +76,14 @@ internal class PreviousState<TState, TTransition, T> : IPreviousState<TState, TT
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PreviousState{TState, TTransition, T}"/> class.
     /// </summary>
     /// <param name="state">The state that this previous state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T, bool>> conditions)
+    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -106,7 +106,7 @@ internal class PreviousState<TState, TTransition, T> : IPreviousState<TState, TT
         var parameter = parameters.GetPreviousParameter<T>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(parameter, token);
+            var result = await condition.Evaluate(parameter, token);
             if (!result)
             {
                 return false;
@@ -140,7 +140,7 @@ internal class PreviousState<TState, TTransition, T1, T2> : IPreviousState<TStat
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -148,7 +148,7 @@ internal class PreviousState<TState, TTransition, T1, T2> : IPreviousState<TStat
     /// </summary>
     /// <param name="state">The state that this previous state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T1, T2, bool>> conditions)
+    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T1, T2>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -171,7 +171,7 @@ internal class PreviousState<TState, TTransition, T1, T2> : IPreviousState<TStat
         var (p1, p2) = parameters.GetPreviousParameters<T1, T2>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(p1, p2, token);
+            var result = await condition.Evaluate(p1, p2, token);
             if (!result)
             {
                 return false;
@@ -206,7 +206,7 @@ internal class PreviousState<TState, TTransition, T1, T2, T3> : IPreviousState<T
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, T3, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2, T3>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -214,7 +214,7 @@ internal class PreviousState<TState, TTransition, T1, T2, T3> : IPreviousState<T
     /// </summary>
     /// <param name="state">The state that this previous state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T1, T2, T3, bool>> conditions)
+    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T1, T2, T3>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -237,7 +237,7 @@ internal class PreviousState<TState, TTransition, T1, T2, T3> : IPreviousState<T
         var (p1, p2, p3) = parameters.GetPreviousParameters<T1, T2, T3>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(p1, p2, p3, token);
+            var result = await condition.Evaluate(p1, p2, p3, token);
             if (!result)
             {
                 return false;
@@ -273,7 +273,7 @@ internal class PreviousState<TState, TTransition, T1, T2, T3, T4> : IPreviousSta
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncFunc<T1, T2, T3, T4, bool>> conditions;
+    private readonly IReadOnlyList<AsyncCondition<T1, T2, T3, T4>> conditions;
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -281,7 +281,7 @@ internal class PreviousState<TState, TTransition, T1, T2, T3, T4> : IPreviousSta
     /// </summary>
     /// <param name="state">The state that this previous state references.</param>
     /// <param name="conditions">The parameterized conditions that must be satisfied before transitioning.</param>
-    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<IAsyncFunc<T1, T2, T3, T4, bool>> conditions)
+    public PreviousState(IState<TState, TTransition> state, IReadOnlyList<AsyncCondition<T1, T2, T3, T4>> conditions)
     {
         State = state;
         this.conditions = conditions;
@@ -304,7 +304,7 @@ internal class PreviousState<TState, TTransition, T1, T2, T3, T4> : IPreviousSta
         var (p1, p2, p3, p4) = parameters.GetPreviousParameters<T1, T2, T3, T4>();
         foreach (var condition in this.conditions)
         {
-            var result = await condition.InvokeAsync(p1, p2, p3, p4, token);
+            var result = await condition.Evaluate(p1, p2, p3, p4, token);
             if (!result)
             {
                 return false;

--- a/src/ZCrew.StateCraft/States/PreviousStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/PreviousStateConfiguration.cs
@@ -1,4 +1,4 @@
-using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.States.Configuration;
 using ZCrew.StateCraft.States.Contracts;
 
@@ -20,7 +20,7 @@ internal class PreviousStateConfiguration<TState, TTransition> : IPartialPreviou
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<bool>> conditions = [];
+    private readonly List<AsyncCondition> conditions = [];
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PreviousStateConfiguration{TState, TTransition}"/> class.
@@ -54,7 +54,7 @@ internal class PreviousStateConfiguration<TState, TTransition> : IPartialPreviou
     }
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<bool> condition)
+    public void Add(AsyncCondition condition)
     {
         this.conditions.Add(condition);
     }
@@ -84,7 +84,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T, bool>> conditions = [];
+    private readonly List<AsyncCondition<T>> conditions = [];
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -119,7 +119,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T>
     }
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T, bool> condition)
+    public void Add(AsyncCondition<T> condition)
     {
         this.conditions.Add(condition);
     }
@@ -150,7 +150,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T1, T2, bool>> conditions = [];
+    private readonly List<AsyncCondition<T1, T2>> conditions = [];
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -185,7 +185,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2>
     }
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T1, T2, bool> condition)
+    public void Add(AsyncCondition<T1, T2> condition)
     {
         this.conditions.Add(condition);
     }
@@ -217,7 +217,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T1, T2, T3, bool>> conditions = [];
+    private readonly List<AsyncCondition<T1, T2, T3>> conditions = [];
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -252,7 +252,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3>
     }
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T1, T2, T3, bool> condition)
+    public void Add(AsyncCondition<T1, T2, T3> condition)
     {
         this.conditions.Add(condition);
     }
@@ -285,7 +285,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3, T4>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncFunc<T1, T2, T3, T4, bool>> conditions = [];
+    private readonly List<AsyncCondition<T1, T2, T3, T4>> conditions = [];
 
     /// <summary>
     ///     Initializes a new instance of the
@@ -320,7 +320,7 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3, T4>
     }
 
     /// <inheritdoc />
-    public void Add(IAsyncFunc<T1, T2, T3, T4, bool> condition)
+    public void Add(AsyncCondition<T1, T2, T3, T4> condition)
     {
         this.conditions.Add(condition);
     }

--- a/src/ZCrew.StateCraft/States/State.cs
+++ b/src/ZCrew.StateCraft/States/State.cs
@@ -1,5 +1,5 @@
-using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions.Contracts;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions.Contracts;
@@ -22,11 +22,11 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncAction<TState>> onActivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState>> onDeactivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, TTransition, TState>> onStateChangeHandlers;
-    private readonly IReadOnlyList<IAsyncAction> onEntryHandlers;
-    private readonly IReadOnlyList<IAsyncAction> onExitHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState>> onActivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState>> onDeactivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, TTransition, TState>> onStateChangeHandlers;
+    private readonly IReadOnlyList<AsyncHandler> onEntryHandlers;
+    private readonly IReadOnlyList<AsyncHandler> onExitHandlers;
     private readonly IReadOnlyList<IAction> actions;
     private readonly IReadOnlyList<ITrigger> triggers;
     private readonly TransitionTable<TState, TTransition> transitionTable = [];
@@ -45,11 +45,11 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
     /// <param name="stateMachine">The state machine that owns this state.</param>
     public State(
         TState state,
-        IReadOnlyList<IAsyncAction<TState>> onActivateHandlers,
-        IReadOnlyList<IAsyncAction<TState>> onDeactivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, TTransition, TState>> onStateChangeHandlers,
-        IReadOnlyList<IAsyncAction> onEntryHandlers,
-        IReadOnlyList<IAsyncAction> onExitHandlers,
+        IReadOnlyList<AsyncHandler<TState>> onActivateHandlers,
+        IReadOnlyList<AsyncHandler<TState>> onDeactivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, TTransition, TState>> onStateChangeHandlers,
+        IReadOnlyList<AsyncHandler> onEntryHandlers,
+        IReadOnlyList<AsyncHandler> onExitHandlers,
         IReadOnlyList<IAction> actions,
         IReadOnlyList<ITrigger> triggers,
         IStateMachine<TState, TTransition> stateMachine
@@ -84,7 +84,7 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
         StateMachine.Tracker?.Activated(this);
         foreach (var handler in this.onActivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnActivate(t => handler.InvokeAsync(StateValue, t), token);
+            await StateMachine.ExceptionBehavior.CallOnActivate(t => handler.Invoke(StateValue, t), token);
         }
     }
 
@@ -94,7 +94,7 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
         StateMachine.Tracker?.Deactivated(this);
         foreach (var handler in this.onDeactivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnDeactivate(t => handler.InvokeAsync(StateValue, t), token);
+            await StateMachine.ExceptionBehavior.CallOnDeactivate(t => handler.Invoke(StateValue, t), token);
         }
     }
 
@@ -109,7 +109,7 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
         foreach (var handler in this.onStateChangeHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnStateChange(
-                t => handler.InvokeAsync(previousState, transition, StateValue, t),
+                t => handler.Invoke(previousState, transition, StateValue, t),
                 token
             );
         }
@@ -121,7 +121,7 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
         StateMachine.Tracker?.Entered(this);
         foreach (var handler in this.onEntryHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnEntry(handler.InvokeAsync, token);
+            await StateMachine.ExceptionBehavior.CallOnEntry(handler.Invoke, token);
         }
 
         foreach (var trigger in this.triggers)
@@ -141,7 +141,7 @@ internal class State<TState, TTransition> : IState<TState, TTransition>
         StateMachine.Tracker?.Exited(this);
         foreach (var handler in this.onExitHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnExit(handler.InvokeAsync, token);
+            await StateMachine.ExceptionBehavior.CallOnExit(handler.Invoke, token);
         }
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration.cs
@@ -1,5 +1,7 @@
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
+using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Triggers;
@@ -16,11 +18,11 @@ internal class StateConfiguration<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncAction<TState>> onActivateHandlers = [];
-    private readonly List<IAsyncAction<TState>> onDeactivateHandlers = [];
-    private readonly List<IAsyncAction<TState, TTransition, TState>> onStateChangeHandlers = [];
-    private readonly List<IAsyncAction> onEntryHandlers = [];
-    private readonly List<IAsyncAction> onExitHandlers = [];
+    private readonly List<AsyncHandler<TState>> onActivateHandlers = [];
+    private readonly List<AsyncHandler<TState>> onDeactivateHandlers = [];
+    private readonly List<AsyncHandler<TState, TTransition, TState>> onStateChangeHandlers = [];
+    private readonly List<AsyncHandler> onEntryHandlers = [];
+    private readonly List<AsyncHandler> onExitHandlers = [];
     private readonly List<IActionConfiguration> actionConfigurations = [];
     private readonly List<ITriggerConfiguration<TState, TTransition>> triggerConfigurations = [];
     private readonly List<ITransitionConfiguration<TState, TTransition>> transitionConfigurations = [];
@@ -107,7 +109,7 @@ internal class StateConfiguration<TState, TTransition>
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnActivate(Action<TState> handler)
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -116,7 +118,7 @@ internal class StateConfiguration<TState, TTransition>
         Func<TState, CancellationToken, Task> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -125,14 +127,14 @@ internal class StateConfiguration<TState, TTransition>
         Func<TState, CancellationToken, ValueTask> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(Action<TState> handler)
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -141,7 +143,7 @@ internal class StateConfiguration<TState, TTransition>
         Func<TState, CancellationToken, Task> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -150,7 +152,7 @@ internal class StateConfiguration<TState, TTransition>
         Func<TState, CancellationToken, ValueTask> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -159,7 +161,7 @@ internal class StateConfiguration<TState, TTransition>
         Action<TState, TTransition, TState> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -168,7 +170,7 @@ internal class StateConfiguration<TState, TTransition>
         Func<TState, TTransition, TState, CancellationToken, Task> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -177,49 +179,49 @@ internal class StateConfiguration<TState, TTransition>
         Func<TState, TTransition, TState, CancellationToken, ValueTask> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnEntry(Action handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnEntry(Func<CancellationToken, Task> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnEntry(Func<CancellationToken, ValueTask> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnExit(Action handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnExit(Func<CancellationToken, Task> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnExit(Func<CancellationToken, ValueTask> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
@@ -1,5 +1,7 @@
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
+using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -15,11 +17,11 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncAction<TState, T1, T2, T3, T4>> onActivateHandlers = [];
-    private readonly List<IAsyncAction<TState, T1, T2, T3, T4>> onDeactivateHandlers = [];
-    private readonly List<IAsyncAction<TState, TTransition, TState, T1, T2, T3, T4>> onStateChangeHandlers = [];
-    private readonly List<IAsyncAction<T1, T2, T3, T4>> onEntryHandlers = [];
-    private readonly List<IAsyncAction<T1, T2, T3, T4>> onExitHandlers = [];
+    private readonly List<AsyncHandler<TState, T1, T2, T3, T4>> onActivateHandlers = [];
+    private readonly List<AsyncHandler<TState, T1, T2, T3, T4>> onDeactivateHandlers = [];
+    private readonly List<AsyncHandler<TState, TTransition, TState, T1, T2, T3, T4>> onStateChangeHandlers = [];
+    private readonly List<AsyncHandler<T1, T2, T3, T4>> onEntryHandlers = [];
+    private readonly List<AsyncHandler<T1, T2, T3, T4>> onExitHandlers = [];
     private readonly List<IActionConfiguration<T1, T2, T3, T4>> actionConfigurations = [];
     private readonly List<ITransitionConfiguration<TState, TTransition>> transitionConfigurations = [];
 
@@ -89,7 +91,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Action<TState, T1, T2, T3, T4> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -98,7 +100,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -107,7 +109,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -116,7 +118,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Action<TState, T1, T2, T3, T4> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -125,7 +127,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -134,7 +136,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -143,7 +145,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Action<TState, TTransition, TState, T1, T2, T3, T4> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -152,7 +154,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, Task> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -161,14 +163,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(Action<T1, T2, T3, T4> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -177,7 +179,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<T1, T2, T3, T4, CancellationToken, Task> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -186,14 +188,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(Action<T1, T2, T3, T4> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -202,7 +204,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<T1, T2, T3, T4, CancellationToken, Task> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -211,7 +213,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
         Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
@@ -1,5 +1,7 @@
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
+using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -15,11 +17,11 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncAction<TState, T1, T2, T3>> onActivateHandlers = [];
-    private readonly List<IAsyncAction<TState, T1, T2, T3>> onDeactivateHandlers = [];
-    private readonly List<IAsyncAction<TState, TTransition, TState, T1, T2, T3>> onStateChangeHandlers = [];
-    private readonly List<IAsyncAction<T1, T2, T3>> onEntryHandlers = [];
-    private readonly List<IAsyncAction<T1, T2, T3>> onExitHandlers = [];
+    private readonly List<AsyncHandler<TState, T1, T2, T3>> onActivateHandlers = [];
+    private readonly List<AsyncHandler<TState, T1, T2, T3>> onDeactivateHandlers = [];
+    private readonly List<AsyncHandler<TState, TTransition, TState, T1, T2, T3>> onStateChangeHandlers = [];
+    private readonly List<AsyncHandler<T1, T2, T3>> onEntryHandlers = [];
+    private readonly List<AsyncHandler<T1, T2, T3>> onExitHandlers = [];
     private readonly List<IActionConfiguration<T1, T2, T3>> actionConfigurations = [];
     private readonly List<ITransitionConfiguration<TState, TTransition>> transitionConfigurations = [];
 
@@ -89,7 +91,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Action<TState, T1, T2, T3> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -98,7 +100,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<TState, T1, T2, T3, CancellationToken, Task> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -107,7 +109,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -116,7 +118,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Action<TState, T1, T2, T3> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -125,7 +127,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<TState, T1, T2, T3, CancellationToken, Task> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -134,7 +136,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -143,7 +145,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Action<TState, TTransition, TState, T1, T2, T3> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -152,7 +154,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, Task> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -161,14 +163,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, ValueTask> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(Action<T1, T2, T3> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -177,7 +179,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<T1, T2, T3, CancellationToken, Task> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -186,14 +188,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<T1, T2, T3, CancellationToken, ValueTask> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(Action<T1, T2, T3> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -202,7 +204,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<T1, T2, T3, CancellationToken, Task> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -211,7 +213,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
         Func<T1, T2, T3, CancellationToken, ValueTask> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
@@ -1,5 +1,7 @@
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
+using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -15,11 +17,11 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncAction<TState, T1, T2>> onActivateHandlers = [];
-    private readonly List<IAsyncAction<TState, T1, T2>> onDeactivateHandlers = [];
-    private readonly List<IAsyncAction<TState, TTransition, TState, T1, T2>> onStateChangeHandlers = [];
-    private readonly List<IAsyncAction<T1, T2>> onEntryHandlers = [];
-    private readonly List<IAsyncAction<T1, T2>> onExitHandlers = [];
+    private readonly List<AsyncHandler<TState, T1, T2>> onActivateHandlers = [];
+    private readonly List<AsyncHandler<TState, T1, T2>> onDeactivateHandlers = [];
+    private readonly List<AsyncHandler<TState, TTransition, TState, T1, T2>> onStateChangeHandlers = [];
+    private readonly List<AsyncHandler<T1, T2>> onEntryHandlers = [];
+    private readonly List<AsyncHandler<T1, T2>> onExitHandlers = [];
     private readonly List<IActionConfiguration<T1, T2>> actionConfigurations = [];
     private readonly List<ITransitionConfiguration<TState, TTransition>> transitionConfigurations = [];
 
@@ -87,7 +89,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(Action<TState, T1, T2> handler)
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -96,7 +98,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<TState, T1, T2, CancellationToken, Task> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -105,14 +107,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<TState, T1, T2, CancellationToken, ValueTask> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(Action<TState, T1, T2> handler)
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -121,7 +123,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<TState, T1, T2, CancellationToken, Task> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -130,7 +132,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<TState, T1, T2, CancellationToken, ValueTask> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -139,7 +141,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Action<TState, TTransition, TState, T1, T2> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -148,7 +150,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<TState, TTransition, TState, T1, T2, CancellationToken, Task> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -157,14 +159,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<TState, TTransition, TState, T1, T2, CancellationToken, ValueTask> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(Action<T1, T2> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -173,7 +175,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<T1, T2, CancellationToken, Task> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -182,14 +184,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<T1, T2, CancellationToken, ValueTask> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(Action<T1, T2> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -198,7 +200,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<T1, T2, CancellationToken, Task> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -207,7 +209,7 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
         Func<T1, T2, CancellationToken, ValueTask> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
@@ -1,5 +1,7 @@
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
+using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -15,11 +17,11 @@ internal class StateConfiguration<TState, TTransition, T>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly List<IAsyncAction<TState, T>> onActivateHandlers = [];
-    private readonly List<IAsyncAction<TState, T>> onDeactivateHandlers = [];
-    private readonly List<IAsyncAction<TState, TTransition, TState, T>> onStateChangeHandlers = [];
-    private readonly List<IAsyncAction<T>> onEntryHandlers = [];
-    private readonly List<IAsyncAction<T>> onExitHandlers = [];
+    private readonly List<AsyncHandler<TState, T>> onActivateHandlers = [];
+    private readonly List<AsyncHandler<TState, T>> onDeactivateHandlers = [];
+    private readonly List<AsyncHandler<TState, TTransition, TState, T>> onStateChangeHandlers = [];
+    private readonly List<AsyncHandler<T>> onEntryHandlers = [];
+    private readonly List<AsyncHandler<T>> onExitHandlers = [];
     private readonly List<IActionConfiguration<T>> actionConfigurations = [];
     private readonly List<ITransitionConfiguration<TState, TTransition>> transitionConfigurations = [];
 
@@ -92,7 +94,7 @@ internal class StateConfiguration<TState, TTransition, T>
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(Action<TState, T> handler)
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -101,7 +103,7 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<TState, T, CancellationToken, Task> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -110,14 +112,14 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<TState, T, CancellationToken, ValueTask> handler
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(Action<TState, T> handler)
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -126,7 +128,7 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<TState, T, CancellationToken, Task> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -135,7 +137,7 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<TState, T, CancellationToken, ValueTask> handler
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -144,7 +146,7 @@ internal class StateConfiguration<TState, TTransition, T>
         Action<TState, TTransition, TState, T> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -153,7 +155,7 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<TState, TTransition, TState, T, CancellationToken, Task> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -162,21 +164,21 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<TState, TTransition, TState, T, CancellationToken, ValueTask> handler
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Action<T> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Func<T, CancellationToken, Task> handler)
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -185,21 +187,21 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<T, CancellationToken, ValueTask> handler
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Action<T> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Func<T, CancellationToken, Task> handler)
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 
@@ -208,7 +210,7 @@ internal class StateConfiguration<TState, TTransition, T>
         Func<T, CancellationToken, ValueTask> handler
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/State{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/State{T1,T2,T3,T4}.cs
@@ -1,5 +1,5 @@
-using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions.Contracts;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions.Contracts;
@@ -13,11 +13,11 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncAction<TState, T1, T2, T3, T4>> onActivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, T1, T2, T3, T4>> onDeactivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, TTransition, TState, T1, T2, T3, T4>> onStateChangeHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T1, T2, T3, T4>> onEntryHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T1, T2, T3, T4>> onExitHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T1, T2, T3, T4>> onActivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T1, T2, T3, T4>> onDeactivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, TTransition, TState, T1, T2, T3, T4>> onStateChangeHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T1, T2, T3, T4>> onEntryHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T1, T2, T3, T4>> onExitHandlers;
     private readonly IReadOnlyList<IAction<T1, T2, T3, T4>> actions;
     private readonly TransitionTable<TState, TTransition> transitionTable = [];
 
@@ -27,11 +27,11 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
     /// </summary>
     public State(
         TState state,
-        IReadOnlyList<IAsyncAction<TState, T1, T2, T3, T4>> onActivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, T1, T2, T3, T4>> onDeactivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, TTransition, TState, T1, T2, T3, T4>> onStateChangeHandlers,
-        IReadOnlyList<IAsyncAction<T1, T2, T3, T4>> onEntryHandlers,
-        IReadOnlyList<IAsyncAction<T1, T2, T3, T4>> onExitHandlers,
+        IReadOnlyList<AsyncHandler<TState, T1, T2, T3, T4>> onActivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, T1, T2, T3, T4>> onDeactivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, TTransition, TState, T1, T2, T3, T4>> onStateChangeHandlers,
+        IReadOnlyList<AsyncHandler<T1, T2, T3, T4>> onEntryHandlers,
+        IReadOnlyList<AsyncHandler<T1, T2, T3, T4>> onExitHandlers,
         IReadOnlyList<IAction<T1, T2, T3, T4>> actions,
         IStateMachine<TState, TTransition> stateMachine
     )
@@ -66,7 +66,7 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         foreach (var handler in this.onActivateHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnActivate(
-                t => handler.InvokeAsync(StateValue, p1, p2, p3, p4, t),
+                t => handler.Invoke(StateValue, p1, p2, p3, p4, t),
                 token
             );
         }
@@ -80,7 +80,7 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         foreach (var handler in this.onDeactivateHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnDeactivate(
-                t => handler.InvokeAsync(StateValue, p1, p2, p3, p4, t),
+                t => handler.Invoke(StateValue, p1, p2, p3, p4, t),
                 token
             );
         }
@@ -98,7 +98,7 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         foreach (var handler in this.onStateChangeHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnStateChange(
-                t => handler.InvokeAsync(previousState, transition, StateValue, p1, p2, p3, p4, t),
+                t => handler.Invoke(previousState, transition, StateValue, p1, p2, p3, p4, t),
                 token
             );
         }
@@ -111,7 +111,7 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         StateMachine.Tracker?.Entered(this, (p1, p2, p3, p4));
         foreach (var handler in this.onEntryHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.InvokeAsync(p1, p2, p3, p4, t), token);
+            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.Invoke(p1, p2, p3, p4, t), token);
         }
     }
 
@@ -122,7 +122,7 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         StateMachine.Tracker?.Exited(this, (p1, p2, p3, p4));
         foreach (var handler in this.onExitHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.InvokeAsync(p1, p2, p3, p4, t), token);
+            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.Invoke(p1, p2, p3, p4, t), token);
         }
     }
 
@@ -152,13 +152,12 @@ internal class State<TState, TTransition, T1, T2, T3, T4> : IState<TState, TTran
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            var available = this.transitionTable
-                .Select(t => t.ToString())
-                .ToList();
+            var available = this.transitionTable.Select(t => t.ToString()).ToList();
 
-            var availableInfo = available.Count > 0
-                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
-                : $" No transitions registered for '{StateValue}'.";
+            var availableInfo =
+                available.Count > 0
+                    ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                    : $" No transitions registered for '{StateValue}'.";
 
             throw new InvalidOperationException(
                 $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"

--- a/src/ZCrew.StateCraft/States/State{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/State{T1,T2,T3}.cs
@@ -1,5 +1,5 @@
-using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions.Contracts;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions.Contracts;
@@ -13,11 +13,11 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncAction<TState, T1, T2, T3>> onActivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, T1, T2, T3>> onDeactivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, TTransition, TState, T1, T2, T3>> onStateChangeHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T1, T2, T3>> onEntryHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T1, T2, T3>> onExitHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T1, T2, T3>> onActivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T1, T2, T3>> onDeactivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, TTransition, TState, T1, T2, T3>> onStateChangeHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T1, T2, T3>> onEntryHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T1, T2, T3>> onExitHandlers;
     private readonly IReadOnlyList<IAction<T1, T2, T3>> actions;
     private readonly TransitionTable<TState, TTransition> transitionTable = [];
 
@@ -26,11 +26,11 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
     /// </summary>
     public State(
         TState state,
-        IReadOnlyList<IAsyncAction<TState, T1, T2, T3>> onActivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, T1, T2, T3>> onDeactivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, TTransition, TState, T1, T2, T3>> onStateChangeHandlers,
-        IReadOnlyList<IAsyncAction<T1, T2, T3>> onEntryHandlers,
-        IReadOnlyList<IAsyncAction<T1, T2, T3>> onExitHandlers,
+        IReadOnlyList<AsyncHandler<TState, T1, T2, T3>> onActivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, T1, T2, T3>> onDeactivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, TTransition, TState, T1, T2, T3>> onStateChangeHandlers,
+        IReadOnlyList<AsyncHandler<T1, T2, T3>> onEntryHandlers,
+        IReadOnlyList<AsyncHandler<T1, T2, T3>> onExitHandlers,
         IReadOnlyList<IAction<T1, T2, T3>> actions,
         IStateMachine<TState, TTransition> stateMachine
     )
@@ -64,10 +64,7 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         StateMachine.Tracker?.Activated(this, (p1, p2, p3));
         foreach (var handler in this.onActivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnActivate(
-                t => handler.InvokeAsync(StateValue, p1, p2, p3, t),
-                token
-            );
+            await StateMachine.ExceptionBehavior.CallOnActivate(t => handler.Invoke(StateValue, p1, p2, p3, t), token);
         }
     }
 
@@ -79,7 +76,7 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         foreach (var handler in this.onDeactivateHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnDeactivate(
-                t => handler.InvokeAsync(StateValue, p1, p2, p3, t),
+                t => handler.Invoke(StateValue, p1, p2, p3, t),
                 token
             );
         }
@@ -97,7 +94,7 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         foreach (var handler in this.onStateChangeHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnStateChange(
-                t => handler.InvokeAsync(previousState, transition, StateValue, p1, p2, p3, t),
+                t => handler.Invoke(previousState, transition, StateValue, p1, p2, p3, t),
                 token
             );
         }
@@ -110,7 +107,7 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         StateMachine.Tracker?.Entered(this, (p1, p2, p3));
         foreach (var handler in this.onEntryHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.InvokeAsync(p1, p2, p3, t), token);
+            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.Invoke(p1, p2, p3, t), token);
         }
     }
 
@@ -121,7 +118,7 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         StateMachine.Tracker?.Exited(this, (p1, p2, p3));
         foreach (var handler in this.onExitHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.InvokeAsync(p1, p2, p3, t), token);
+            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.Invoke(p1, p2, p3, t), token);
         }
     }
 
@@ -151,13 +148,12 @@ internal class State<TState, TTransition, T1, T2, T3> : IState<TState, TTransiti
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            var available = this.transitionTable
-                .Select(t => t.ToString())
-                .ToList();
+            var available = this.transitionTable.Select(t => t.ToString()).ToList();
 
-            var availableInfo = available.Count > 0
-                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
-                : $" No transitions registered for '{StateValue}'.";
+            var availableInfo =
+                available.Count > 0
+                    ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                    : $" No transitions registered for '{StateValue}'.";
 
             throw new InvalidOperationException(
                 $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"

--- a/src/ZCrew.StateCraft/States/State{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/State{T1,T2}.cs
@@ -1,5 +1,5 @@
-using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions.Contracts;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions.Contracts;
@@ -13,11 +13,11 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncAction<TState, T1, T2>> onActivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, T1, T2>> onDeactivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, TTransition, TState, T1, T2>> onStateChangeHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T1, T2>> onEntryHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T1, T2>> onExitHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T1, T2>> onActivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T1, T2>> onDeactivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, TTransition, TState, T1, T2>> onStateChangeHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T1, T2>> onEntryHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T1, T2>> onExitHandlers;
     private readonly IReadOnlyList<IAction<T1, T2>> actions;
     private readonly TransitionTable<TState, TTransition> transitionTable = [];
 
@@ -26,11 +26,11 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
     /// </summary>
     public State(
         TState state,
-        IReadOnlyList<IAsyncAction<TState, T1, T2>> onActivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, T1, T2>> onDeactivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, TTransition, TState, T1, T2>> onStateChangeHandlers,
-        IReadOnlyList<IAsyncAction<T1, T2>> onEntryHandlers,
-        IReadOnlyList<IAsyncAction<T1, T2>> onExitHandlers,
+        IReadOnlyList<AsyncHandler<TState, T1, T2>> onActivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, T1, T2>> onDeactivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, TTransition, TState, T1, T2>> onStateChangeHandlers,
+        IReadOnlyList<AsyncHandler<T1, T2>> onEntryHandlers,
+        IReadOnlyList<AsyncHandler<T1, T2>> onExitHandlers,
         IReadOnlyList<IAction<T1, T2>> actions,
         IStateMachine<TState, TTransition> stateMachine
     )
@@ -64,7 +64,7 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         StateMachine.Tracker?.Activated(this, (p1, p2));
         foreach (var handler in this.onActivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnActivate(t => handler.InvokeAsync(StateValue, p1, p2, t), token);
+            await StateMachine.ExceptionBehavior.CallOnActivate(t => handler.Invoke(StateValue, p1, p2, t), token);
         }
     }
 
@@ -75,10 +75,7 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         StateMachine.Tracker?.Deactivated(this, (p1, p2));
         foreach (var handler in this.onDeactivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnDeactivate(
-                t => handler.InvokeAsync(StateValue, p1, p2, t),
-                token
-            );
+            await StateMachine.ExceptionBehavior.CallOnDeactivate(t => handler.Invoke(StateValue, p1, p2, t), token);
         }
     }
 
@@ -94,7 +91,7 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         foreach (var handler in this.onStateChangeHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnStateChange(
-                t => handler.InvokeAsync(previousState, transition, StateValue, p1, p2, t),
+                t => handler.Invoke(previousState, transition, StateValue, p1, p2, t),
                 token
             );
         }
@@ -107,7 +104,7 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         StateMachine.Tracker?.Entered(this, (p1, p2));
         foreach (var handler in this.onEntryHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.InvokeAsync(p1, p2, t), token);
+            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.Invoke(p1, p2, t), token);
         }
     }
 
@@ -118,7 +115,7 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         StateMachine.Tracker?.Exited(this, (p1, p2));
         foreach (var handler in this.onExitHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.InvokeAsync(p1, p2, t), token);
+            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.Invoke(p1, p2, t), token);
         }
     }
 
@@ -148,13 +145,12 @@ internal class State<TState, TTransition, T1, T2> : IState<TState, TTransition>
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            var available = this.transitionTable
-                .Select(t => t.ToString())
-                .ToList();
+            var available = this.transitionTable.Select(t => t.ToString()).ToList();
 
-            var availableInfo = available.Count > 0
-                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
-                : $" No transitions registered for '{StateValue}'.";
+            var availableInfo =
+                available.Count > 0
+                    ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                    : $" No transitions registered for '{StateValue}'.";
 
             throw new InvalidOperationException(
                 $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"

--- a/src/ZCrew.StateCraft/States/State{T}.cs
+++ b/src/ZCrew.StateCraft/States/State{T}.cs
@@ -1,5 +1,5 @@
-using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions.Contracts;
+using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Parameters.Contracts;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions.Contracts;
@@ -22,11 +22,11 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
-    private readonly IReadOnlyList<IAsyncAction<TState, T>> onActivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, T>> onDeactivateHandlers;
-    private readonly IReadOnlyList<IAsyncAction<TState, TTransition, TState, T>> onStateChangeHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T>> onEntryHandlers;
-    private readonly IReadOnlyList<IAsyncAction<T>> onExitHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T>> onActivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, T>> onDeactivateHandlers;
+    private readonly IReadOnlyList<AsyncHandler<TState, TTransition, TState, T>> onStateChangeHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T>> onEntryHandlers;
+    private readonly IReadOnlyList<AsyncHandler<T>> onExitHandlers;
     private readonly IReadOnlyList<IAction<T>> actions;
     private readonly TransitionTable<TState, TTransition> transitionTable = [];
 
@@ -43,11 +43,11 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
     /// <param name="stateMachine">The state machine that owns this state.</param>
     public State(
         TState state,
-        IReadOnlyList<IAsyncAction<TState, T>> onActivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, T>> onDeactivateHandlers,
-        IReadOnlyList<IAsyncAction<TState, TTransition, TState, T>> onStateChangeHandlers,
-        IReadOnlyList<IAsyncAction<T>> onEntryHandlers,
-        IReadOnlyList<IAsyncAction<T>> onExitHandlers,
+        IReadOnlyList<AsyncHandler<TState, T>> onActivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, T>> onDeactivateHandlers,
+        IReadOnlyList<AsyncHandler<TState, TTransition, TState, T>> onStateChangeHandlers,
+        IReadOnlyList<AsyncHandler<T>> onEntryHandlers,
+        IReadOnlyList<AsyncHandler<T>> onExitHandlers,
         IReadOnlyList<IAction<T>> actions,
         IStateMachine<TState, TTransition> stateMachine
     )
@@ -81,10 +81,7 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         StateMachine.Tracker?.Activated(this, parameter);
         foreach (var handler in this.onActivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnActivate(
-                t => handler.InvokeAsync(StateValue, parameter, t),
-                token
-            );
+            await StateMachine.ExceptionBehavior.CallOnActivate(t => handler.Invoke(StateValue, parameter, t), token);
         }
     }
 
@@ -95,10 +92,7 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         StateMachine.Tracker?.Deactivated(this, parameter);
         foreach (var handler in this.onDeactivateHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnDeactivate(
-                t => handler.InvokeAsync(StateValue, parameter, t),
-                token
-            );
+            await StateMachine.ExceptionBehavior.CallOnDeactivate(t => handler.Invoke(StateValue, parameter, t), token);
         }
     }
 
@@ -114,7 +108,7 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         foreach (var handler in this.onStateChangeHandlers)
         {
             await StateMachine.ExceptionBehavior.CallOnStateChange(
-                t => handler.InvokeAsync(previousState, transition, StateValue, parameter, t),
+                t => handler.Invoke(previousState, transition, StateValue, parameter, t),
                 token
             );
         }
@@ -127,7 +121,7 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         StateMachine.Tracker?.Entered(this, parameter);
         foreach (var handler in this.onEntryHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.InvokeAsync(parameter, t), token);
+            await StateMachine.ExceptionBehavior.CallOnEntry(t => handler.Invoke(parameter, t), token);
         }
     }
 
@@ -138,7 +132,7 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         StateMachine.Tracker?.Exited(this, parameter);
         foreach (var handler in this.onExitHandlers)
         {
-            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.InvokeAsync(parameter, t), token);
+            await StateMachine.ExceptionBehavior.CallOnExit(t => handler.Invoke(parameter, t), token);
         }
     }
 
@@ -168,13 +162,12 @@ internal class State<TState, TTransition, T> : IState<TState, TTransition>
         var result = await this.transitionTable.LookupTransition(transition, parameters, token);
         if (result == null)
         {
-            var available = this.transitionTable
-                .Select(t => t.ToString())
-                .ToList();
+            var available = this.transitionTable.Select(t => t.ToString()).ToList();
 
-            var availableInfo = available.Count > 0
-                ? $" Available from '{StateValue}': {string.Join(", ", available)}."
-                : $" No transitions registered for '{StateValue}'.";
+            var availableInfo =
+                available.Count > 0
+                    ? $" Available from '{StateValue}': {string.Join(", ", available)}."
+                    : $" No transitions registered for '{StateValue}'.";
 
             throw new InvalidOperationException(
                 $"No transition could be found for '{transition}' from state '{StateValue}'.{availableInfo}"

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
 
@@ -35,21 +36,21 @@ internal class InitialTransitionConfiguration<TState, TTransition>
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition> If(Func<bool> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, Task<bool>> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, ValueTask<bool>> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3,T4}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
@@ -31,7 +32,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(Func<T1, T2, T3, T4, bool> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -40,7 +41,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T
         Func<T1, T2, T3, T4, CancellationToken, Task<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -49,7 +50,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T
         Func<T1, T2, T3, T4, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
@@ -31,7 +32,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3>
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(Func<T1, T2, T3, bool> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -40,7 +41,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3>
         Func<T1, T2, T3, CancellationToken, Task<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -49,7 +50,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3>
         Func<T1, T2, T3, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
@@ -29,7 +30,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2>
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(Func<T1, T2, bool> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -38,7 +39,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2>
         Func<T1, T2, CancellationToken, Task<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -47,7 +48,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2>
         Func<T1, T2, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
@@ -36,14 +37,14 @@ internal class InitialTransitionConfiguration<TState, TTransition, T>
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, bool> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, CancellationToken, Task<bool>> condition)
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -52,7 +53,7 @@ internal class InitialTransitionConfiguration<TState, TTransition, T>
         Func<T, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
 
@@ -49,21 +50,21 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition>
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition> If(Func<bool> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, Task<bool>> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, ValueTask<bool>> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3,TNext4}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3,TNext4}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
 
@@ -59,7 +60,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, TNext4, bool> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -68,7 +69,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -77,7 +78,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
 
@@ -51,7 +52,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, bool> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -60,7 +61,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -69,7 +70,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
 
@@ -49,7 +50,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(Func<TNext1, TNext2, bool> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -58,7 +59,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -67,7 +68,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext}.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
 
@@ -49,7 +50,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext>
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, bool> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -58,7 +59,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext>
         Func<TNext, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -67,7 +68,7 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext>
         Func<TNext, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialMappedTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialMappedTransitionConfiguration.cs
@@ -1,4 +1,5 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping.Contracts;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
@@ -55,7 +56,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext>
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, bool> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -64,7 +65,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext>
         Func<TNext, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -73,7 +74,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext>
         Func<TNext, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -134,7 +135,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(Func<TNext1, TNext2, bool> condition)
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -143,7 +144,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -152,7 +153,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -215,7 +216,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, bool> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -224,7 +225,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -233,7 +234,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -304,7 +305,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, TNext4, bool> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -313,7 +314,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 
@@ -322,7 +323,7 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
         Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
         return this;
     }
 


### PR DESCRIPTION
Adds a wrapper type so metadata can easily be packaged into these conditions and handlers.

Since the mapping, loading initial state, actions, and triggers probably won't be a part of the state machine diagrams: these weren't wrapped.

Closes #155