### PR TITLE
#155 - Add descriptor to delegates

### DIFF
--- a/src/ZCrew.StateCraft/Async/AsyncCondition.cs
+++ b/src/ZCrew.StateCraft/Async/AsyncCondition.cs
@@ -11,7 +11,10 @@ namespace ZCrew.StateCraft.Async;
 ///     which allows additional metadata to be associated with conditions in the future without changing call sites.
 /// </remarks>
 /// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
-internal readonly record struct AsyncCondition(IAsyncFunc<bool> Condition)
+/// <param name="Descriptor">
+///     An optional descriptor identifying the condition, captured from the caller's expression.
+/// </param>
+internal readonly record struct AsyncCondition(IAsyncFunc<bool> Condition, string? Descriptor)
 {
     /// <summary>
     ///     Evaluates the wrapped condition.
@@ -34,7 +37,10 @@ internal readonly record struct AsyncCondition(IAsyncFunc<bool> Condition)
 /// </remarks>
 /// <typeparam name="T">The type of the parameter passed to the condition.</typeparam>
 /// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
-internal readonly record struct AsyncCondition<T>(IAsyncFunc<T, bool> Condition)
+/// <param name="Descriptor">
+///     An optional descriptor identifying the condition, captured from the caller's expression.
+/// </param>
+internal readonly record struct AsyncCondition<T>(IAsyncFunc<T, bool> Condition, string? Descriptor)
 {
     /// <summary>
     ///     Evaluates the wrapped condition with the provided parameter.
@@ -59,7 +65,10 @@ internal readonly record struct AsyncCondition<T>(IAsyncFunc<T, bool> Condition)
 /// <typeparam name="T1">The type of the first parameter passed to the condition.</typeparam>
 /// <typeparam name="T2">The type of the second parameter passed to the condition.</typeparam>
 /// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
-internal readonly record struct AsyncCondition<T1, T2>(IAsyncFunc<T1, T2, bool> Condition)
+/// <param name="Descriptor">
+///     An optional descriptor identifying the condition, captured from the caller's expression.
+/// </param>
+internal readonly record struct AsyncCondition<T1, T2>(IAsyncFunc<T1, T2, bool> Condition, string? Descriptor)
 {
     /// <summary>
     ///     Evaluates the wrapped condition with the provided parameters.
@@ -86,7 +95,10 @@ internal readonly record struct AsyncCondition<T1, T2>(IAsyncFunc<T1, T2, bool> 
 /// <typeparam name="T2">The type of the second parameter passed to the condition.</typeparam>
 /// <typeparam name="T3">The type of the third parameter passed to the condition.</typeparam>
 /// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
-internal readonly record struct AsyncCondition<T1, T2, T3>(IAsyncFunc<T1, T2, T3, bool> Condition)
+/// <param name="Descriptor">
+///     An optional descriptor identifying the condition, captured from the caller's expression.
+/// </param>
+internal readonly record struct AsyncCondition<T1, T2, T3>(IAsyncFunc<T1, T2, T3, bool> Condition, string? Descriptor)
 {
     /// <summary>
     ///     Evaluates the wrapped condition with the provided parameters.
@@ -115,7 +127,13 @@ internal readonly record struct AsyncCondition<T1, T2, T3>(IAsyncFunc<T1, T2, T3
 /// <typeparam name="T3">The type of the third parameter passed to the condition.</typeparam>
 /// <typeparam name="T4">The type of the fourth parameter passed to the condition.</typeparam>
 /// <param name="Condition">The underlying asynchronous predicate that is evaluated when the condition runs.</param>
-internal readonly record struct AsyncCondition<T1, T2, T3, T4>(IAsyncFunc<T1, T2, T3, T4, bool> Condition)
+/// <param name="Descriptor">
+///     An optional descriptor identifying the condition, captured from the caller's expression.
+/// </param>
+internal readonly record struct AsyncCondition<T1, T2, T3, T4>(
+    IAsyncFunc<T1, T2, T3, T4, bool> Condition,
+    string? Descriptor
+)
 {
     /// <summary>
     ///     Evaluates the wrapped condition with the provided parameters.

--- a/src/ZCrew.StateCraft/Async/AsyncHandler.cs
+++ b/src/ZCrew.StateCraft/Async/AsyncHandler.cs
@@ -11,7 +11,8 @@ namespace ZCrew.StateCraft.Async;
 ///     which allows additional metadata to be associated with handlers in the future without changing call sites.
 /// </remarks>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler(IAsyncAction Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler(IAsyncAction Handler, string? Descriptor)
 {
     /// <summary>
     ///     Invokes the wrapped handler.
@@ -34,7 +35,8 @@ internal readonly record struct AsyncHandler(IAsyncAction Handler)
 /// </remarks>
 /// <typeparam name="T">The type of the parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler<T>(IAsyncAction<T> Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler<T>(IAsyncAction<T> Handler, string? Descriptor)
 {
     /// <summary>
     ///     Invokes the wrapped handler with the provided parameter.
@@ -59,7 +61,8 @@ internal readonly record struct AsyncHandler<T>(IAsyncAction<T> Handler)
 /// <typeparam name="T1">The type of the first parameter passed to the handler.</typeparam>
 /// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler<T1, T2>(IAsyncAction<T1, T2> Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler<T1, T2>(IAsyncAction<T1, T2> Handler, string? Descriptor)
 {
     /// <summary>
     ///     Invokes the wrapped handler with the provided parameters.
@@ -86,7 +89,8 @@ internal readonly record struct AsyncHandler<T1, T2>(IAsyncAction<T1, T2> Handle
 /// <typeparam name="T2">The type of the second parameter passed to the handler.</typeparam>
 /// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler<T1, T2, T3>(IAsyncAction<T1, T2, T3> Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3>(IAsyncAction<T1, T2, T3> Handler, string? Descriptor)
 {
     /// <summary>
     ///     Invokes the wrapped handler with the provided parameters.
@@ -115,7 +119,8 @@ internal readonly record struct AsyncHandler<T1, T2, T3>(IAsyncAction<T1, T2, T3
 /// <typeparam name="T3">The type of the third parameter passed to the handler.</typeparam>
 /// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler<T1, T2, T3, T4>(IAsyncAction<T1, T2, T3, T4> Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4>(IAsyncAction<T1, T2, T3, T4> Handler, string? Descriptor)
 {
     /// <summary>
     ///     Invokes the wrapped handler with the provided parameters.
@@ -146,7 +151,11 @@ internal readonly record struct AsyncHandler<T1, T2, T3, T4>(IAsyncAction<T1, T2
 /// <typeparam name="T4">The type of the fourth parameter passed to the handler.</typeparam>
 /// <typeparam name="T5">The type of the fifth parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5>(IAsyncAction<T1, T2, T3, T4, T5> Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5>(
+    IAsyncAction<T1, T2, T3, T4, T5> Handler,
+    string? Descriptor
+)
 {
     /// <summary>
     ///     Invokes the wrapped handler with the provided parameters.
@@ -186,7 +195,11 @@ internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5>(IAsyncAction<T1
 /// <typeparam name="T5">The type of the fifth parameter passed to the handler.</typeparam>
 /// <typeparam name="T6">The type of the sixth parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
-internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6>(IAsyncAction<T1, T2, T3, T4, T5, T6> Handler)
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
+internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6>(
+    IAsyncAction<T1, T2, T3, T4, T5, T6> Handler,
+    string? Descriptor
+)
 {
     /// <summary>
     ///     Invokes the wrapped handler with the provided parameters.
@@ -229,8 +242,10 @@ internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6>(IAsyncActio
 /// <typeparam name="T6">The type of the sixth parameter passed to the handler.</typeparam>
 /// <typeparam name="T7">The type of the seventh parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
 internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6, T7>(
-    IAsyncAction<T1, T2, T3, T4, T5, T6, T7> Handler
+    IAsyncAction<T1, T2, T3, T4, T5, T6, T7> Handler,
+    string? Descriptor
 )
 {
     /// <summary>
@@ -286,8 +301,10 @@ internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6, T7>(
 /// <typeparam name="T7">The type of the seventh parameter passed to the handler.</typeparam>
 /// <typeparam name="T8">The type of the eighth parameter passed to the handler.</typeparam>
 /// <param name="Handler">The underlying asynchronous action that is invoked when the handler runs.</param>
+/// <param name="Descriptor">An optional descriptor identifying the handler, captured from the caller's expression.</param>
 internal readonly record struct AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(
-    IAsyncAction<T1, T2, T3, T4, T5, T6, T7, T8> Handler
+    IAsyncAction<T1, T2, T3, T4, T5, T6, T7, T8> Handler,
+    string? Descriptor
 )
 {
     /// <summary>

--- a/src/ZCrew.StateCraft/Extensions/AsyncActionExtensions.cs
+++ b/src/ZCrew.StateCraft/Extensions/AsyncActionExtensions.cs
@@ -17,10 +17,13 @@ internal static class AsyncActionExtensions
     ///     Wraps a parameterless asynchronous action as an <see cref="AsyncHandler"/>.
     /// </summary>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncHandler"/> that delegates invocation to <paramref name="action"/>.</returns>
-    public static AsyncHandler AsAsyncHandler(this IAsyncAction action)
+    public static AsyncHandler AsAsyncHandler(this IAsyncAction action, string? descriptor = null)
     {
-        return new AsyncHandler(action);
+        return new AsyncHandler(action, descriptor);
     }
 
     /// <summary>
@@ -28,10 +31,13 @@ internal static class AsyncActionExtensions
     /// </summary>
     /// <typeparam name="T">The type of the parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncHandler{T}"/> that delegates invocation to <paramref name="action"/>.</returns>
-    public static AsyncHandler<T> AsAsyncHandler<T>(this IAsyncAction<T> action)
+    public static AsyncHandler<T> AsAsyncHandler<T>(this IAsyncAction<T> action, string? descriptor = null)
     {
-        return new AsyncHandler<T>(action);
+        return new AsyncHandler<T>(action, descriptor);
     }
 
     /// <summary>
@@ -40,10 +46,16 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T1">The type of the first parameter passed to the action.</typeparam>
     /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncHandler{T1, T2}"/> that delegates invocation to <paramref name="action"/>.</returns>
-    public static AsyncHandler<T1, T2> AsAsyncHandler<T1, T2>(this IAsyncAction<T1, T2> action)
+    public static AsyncHandler<T1, T2> AsAsyncHandler<T1, T2>(
+        this IAsyncAction<T1, T2> action,
+        string? descriptor = null
+    )
     {
-        return new AsyncHandler<T1, T2>(action);
+        return new AsyncHandler<T1, T2>(action, descriptor);
     }
 
     /// <summary>
@@ -53,10 +65,16 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T2">The type of the second parameter passed to the action.</typeparam>
     /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncHandler{T1, T2, T3}"/> that delegates invocation to <paramref name="action"/>.</returns>
-    public static AsyncHandler<T1, T2, T3> AsAsyncHandler<T1, T2, T3>(this IAsyncAction<T1, T2, T3> action)
+    public static AsyncHandler<T1, T2, T3> AsAsyncHandler<T1, T2, T3>(
+        this IAsyncAction<T1, T2, T3> action,
+        string? descriptor = null
+    )
     {
-        return new AsyncHandler<T1, T2, T3>(action);
+        return new AsyncHandler<T1, T2, T3>(action, descriptor);
     }
 
     /// <summary>
@@ -67,12 +85,18 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T3">The type of the third parameter passed to the action.</typeparam>
     /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>
     ///     An <see cref="AsyncHandler{T1, T2, T3, T4}"/> that delegates invocation to <paramref name="action"/>.
     /// </returns>
-    public static AsyncHandler<T1, T2, T3, T4> AsAsyncHandler<T1, T2, T3, T4>(this IAsyncAction<T1, T2, T3, T4> action)
+    public static AsyncHandler<T1, T2, T3, T4> AsAsyncHandler<T1, T2, T3, T4>(
+        this IAsyncAction<T1, T2, T3, T4> action,
+        string? descriptor = null
+    )
     {
-        return new AsyncHandler<T1, T2, T3, T4>(action);
+        return new AsyncHandler<T1, T2, T3, T4>(action, descriptor);
     }
 
     /// <summary>
@@ -84,14 +108,18 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T4">The type of the fourth parameter passed to the action.</typeparam>
     /// <typeparam name="T5">The type of the fifth parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>
     ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5}"/> that delegates invocation to <paramref name="action"/>.
     /// </returns>
     public static AsyncHandler<T1, T2, T3, T4, T5> AsAsyncHandler<T1, T2, T3, T4, T5>(
-        this IAsyncAction<T1, T2, T3, T4, T5> action
+        this IAsyncAction<T1, T2, T3, T4, T5> action,
+        string? descriptor = null
     )
     {
-        return new AsyncHandler<T1, T2, T3, T4, T5>(action);
+        return new AsyncHandler<T1, T2, T3, T4, T5>(action, descriptor);
     }
 
     /// <summary>
@@ -104,14 +132,18 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T5">The type of the fifth parameter passed to the action.</typeparam>
     /// <typeparam name="T6">The type of the sixth parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>
     ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6}"/> that delegates invocation to <paramref name="action"/>.
     /// </returns>
     public static AsyncHandler<T1, T2, T3, T4, T5, T6> AsAsyncHandler<T1, T2, T3, T4, T5, T6>(
-        this IAsyncAction<T1, T2, T3, T4, T5, T6> action
+        this IAsyncAction<T1, T2, T3, T4, T5, T6> action,
+        string? descriptor = null
     )
     {
-        return new AsyncHandler<T1, T2, T3, T4, T5, T6>(action);
+        return new AsyncHandler<T1, T2, T3, T4, T5, T6>(action, descriptor);
     }
 
     /// <summary>
@@ -125,15 +157,19 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T6">The type of the sixth parameter passed to the action.</typeparam>
     /// <typeparam name="T7">The type of the seventh parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>
     ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6, T7}"/> that delegates invocation to
     ///     <paramref name="action"/>.
     /// </returns>
     public static AsyncHandler<T1, T2, T3, T4, T5, T6, T7> AsAsyncHandler<T1, T2, T3, T4, T5, T6, T7>(
-        this IAsyncAction<T1, T2, T3, T4, T5, T6, T7> action
+        this IAsyncAction<T1, T2, T3, T4, T5, T6, T7> action,
+        string? descriptor = null
     )
     {
-        return new AsyncHandler<T1, T2, T3, T4, T5, T6, T7>(action);
+        return new AsyncHandler<T1, T2, T3, T4, T5, T6, T7>(action, descriptor);
     }
 
     /// <summary>
@@ -149,14 +185,18 @@ internal static class AsyncActionExtensions
     /// <typeparam name="T7">The type of the seventh parameter passed to the action.</typeparam>
     /// <typeparam name="T8">The type of the eighth parameter passed to the action.</typeparam>
     /// <param name="action">The asynchronous action to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>
     ///     An <see cref="AsyncHandler{T1, T2, T3, T4, T5, T6, T7, T8}"/> that delegates invocation to
     ///     <paramref name="action"/>.
     /// </returns>
     public static AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8> AsAsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(
-        this IAsyncAction<T1, T2, T3, T4, T5, T6, T7, T8> action
+        this IAsyncAction<T1, T2, T3, T4, T5, T6, T7, T8> action,
+        string? descriptor = null
     )
     {
-        return new AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(action);
+        return new AsyncHandler<T1, T2, T3, T4, T5, T6, T7, T8>(action, descriptor);
     }
 }

--- a/src/ZCrew.StateCraft/Extensions/AsyncFuncExtensions.cs
+++ b/src/ZCrew.StateCraft/Extensions/AsyncFuncExtensions.cs
@@ -17,10 +17,13 @@ internal static class AsyncFuncExtensions
     ///     Wraps a parameterless asynchronous predicate as an <see cref="AsyncCondition"/>.
     /// </summary>
     /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncCondition"/> that delegates evaluation to <paramref name="func"/>.</returns>
-    public static AsyncCondition AsAsyncCondition(this IAsyncFunc<bool> func)
+    public static AsyncCondition AsAsyncCondition(this IAsyncFunc<bool> func, string? descriptor = null)
     {
-        return new AsyncCondition(func);
+        return new AsyncCondition(func, descriptor);
     }
 
     /// <summary>
@@ -28,10 +31,13 @@ internal static class AsyncFuncExtensions
     /// </summary>
     /// <typeparam name="T">The type of the parameter passed to the predicate.</typeparam>
     /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncCondition{T}"/> that delegates evaluation to <paramref name="func"/>.</returns>
-    public static AsyncCondition<T> AsAsyncCondition<T>(this IAsyncFunc<T, bool> func)
+    public static AsyncCondition<T> AsAsyncCondition<T>(this IAsyncFunc<T, bool> func, string? descriptor = null)
     {
-        return new AsyncCondition<T>(func);
+        return new AsyncCondition<T>(func, descriptor);
     }
 
     /// <summary>
@@ -40,10 +46,16 @@ internal static class AsyncFuncExtensions
     /// <typeparam name="T1">The type of the first parameter passed to the predicate.</typeparam>
     /// <typeparam name="T2">The type of the second parameter passed to the predicate.</typeparam>
     /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncCondition{T1, T2}"/> that delegates evaluation to <paramref name="func"/>.</returns>
-    public static AsyncCondition<T1, T2> AsAsyncCondition<T1, T2>(this IAsyncFunc<T1, T2, bool> func)
+    public static AsyncCondition<T1, T2> AsAsyncCondition<T1, T2>(
+        this IAsyncFunc<T1, T2, bool> func,
+        string? descriptor = null
+    )
     {
-        return new AsyncCondition<T1, T2>(func);
+        return new AsyncCondition<T1, T2>(func, descriptor);
     }
 
     /// <summary>
@@ -53,10 +65,16 @@ internal static class AsyncFuncExtensions
     /// <typeparam name="T2">The type of the second parameter passed to the predicate.</typeparam>
     /// <typeparam name="T3">The type of the third parameter passed to the predicate.</typeparam>
     /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>An <see cref="AsyncCondition{T1, T2, T3}"/> that delegates evaluation to <paramref name="func"/>.</returns>
-    public static AsyncCondition<T1, T2, T3> AsAsyncCondition<T1, T2, T3>(this IAsyncFunc<T1, T2, T3, bool> func)
+    public static AsyncCondition<T1, T2, T3> AsAsyncCondition<T1, T2, T3>(
+        this IAsyncFunc<T1, T2, T3, bool> func,
+        string? descriptor = null
+    )
     {
-        return new AsyncCondition<T1, T2, T3>(func);
+        return new AsyncCondition<T1, T2, T3>(func, descriptor);
     }
 
     /// <summary>
@@ -67,13 +85,17 @@ internal static class AsyncFuncExtensions
     /// <typeparam name="T3">The type of the third parameter passed to the predicate.</typeparam>
     /// <typeparam name="T4">The type of the fourth parameter passed to the predicate.</typeparam>
     /// <param name="func">The asynchronous predicate to wrap.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, no descriptor is captured.
+    /// </param>
     /// <returns>
     ///     An <see cref="AsyncCondition{T1, T2, T3, T4}"/> that delegates evaluation to <paramref name="func"/>.
     /// </returns>
     public static AsyncCondition<T1, T2, T3, T4> AsAsyncCondition<T1, T2, T3, T4>(
-        this IAsyncFunc<T1, T2, T3, T4, bool> func
+        this IAsyncFunc<T1, T2, T3, T4, bool> func,
+        string? descriptor = null
     )
     {
-        return new AsyncCondition<T1, T2, T3, T4>(func);
+        return new AsyncCondition<T1, T2, T3, T4>(func, descriptor);
     }
 }

--- a/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T1,T2,T3,T4}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -20,75 +22,94 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T1, T2, T
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Action{TState})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Action{TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnActivate(
-        Action<TState, T1, T2, T3, T4> handler
+        Action<TState, T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnActivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,ValueTask}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnActivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Action{TState})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Action{TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnDeactivate(
-        Action<TState, T1, T2, T3, T4> handler
+        Action<TState, T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnDeactivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,ValueTask}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnDeactivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Action{TState,TTransition,TState})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Action{TState,TTransition,TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnStateChange(
-        Action<TState, TTransition, TState, T1, T2, T3, T4> handler
+        Action<TState, TTransition, TState, T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,ValueTask}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Action)"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(Action<T1, T2, T3, T4> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Action, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(
-        Func<T1, T2, T3, T4, CancellationToken, Task> handler
+        Action<T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(
-        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Action)"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(Action<T1, T2, T3, T4> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,Task})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
-        Func<T1, T2, T3, T4, CancellationToken, Task> handler
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(
+        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Action, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
-        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Action<T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,Task}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
+        Func<T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
+        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.WithAction"/>

--- a/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T1,T2,T3}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -19,71 +21,94 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T1, T2, T
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Action{TState})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(Action<TState, T1, T2, T3> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Action{TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(
-        Func<TState, T1, T2, T3, CancellationToken, Task> handler
+        Action<TState, T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(
-        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Action{TState})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(Action<TState, T1, T2, T3> handler);
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(
+        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Action{TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(
-        Func<TState, T1, T2, T3, CancellationToken, Task> handler
+        Action<TState, T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(
-        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Action{TState,TTransition,TState})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(
+        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Action{TState,TTransition,TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnStateChange(
-        Action<TState, TTransition, TState, T1, T2, T3> handler
+        Action<TState, TTransition, TState, T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,ValueTask}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Action)"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(Action<T1, T2, T3> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Action, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(
-        Func<T1, T2, T3, CancellationToken, Task> handler
+        Action<T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(
-        Func<T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Action)"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(Action<T1, T2, T3> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,Task})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
-        Func<T1, T2, T3, CancellationToken, Task> handler
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(
+        Func<T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Action, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
-        Func<T1, T2, T3, CancellationToken, ValueTask> handler
+        Action<T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,Task}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
+        Func<T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
+        Func<T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.WithAction"/>

--- a/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T1,T2}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -18,69 +20,94 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T1, T2>
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Action{TState})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(Action<TState, T1, T2> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Action{TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(
-        Func<TState, T1, T2, CancellationToken, Task> handler
+        Action<TState, T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(
-        Func<TState, T1, T2, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Action{TState})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(Action<TState, T1, T2> handler);
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnActivate(Func{TState,CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(
+        Func<TState, T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Action{TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(
-        Func<TState, T1, T2, CancellationToken, Task> handler
+        Action<TState, T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(
-        Func<TState, T1, T2, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Action{TState,TTransition,TState})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnDeactivate(Func{TState,CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(
+        Func<TState, T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Action{TState,TTransition,TState}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnStateChange(
-        Action<TState, TTransition, TState, T1, T2> handler
+        Action<TState, TTransition, TState, T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnStateChange(Func{TState,TTransition,TState,CancellationToken,ValueTask}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Action)"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(Action<T1, T2> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,Task})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Action, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(
-        Func<T1, T2, CancellationToken, Task> handler
+        Action<T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,Task}, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(
-        Func<T1, T2, CancellationToken, ValueTask> handler
+        Func<T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Action)"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(Action<T1, T2> handler);
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnEntry(Func{CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(
+        Func<T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,Task})"/>
-    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(Func<T1, T2, CancellationToken, Task> handler);
-
-    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,ValueTask})"/>
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Action, string?)"/>
     IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
-        Func<T1, T2, CancellationToken, ValueTask> handler
+        Action<T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,Task}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
+        Func<T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.OnExit(Func{CancellationToken,ValueTask}, string?)"/>
+    IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
+        Func<T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}.WithAction"/>

--- a/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IParameterizedStateConfiguration{T}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -32,17 +34,29 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     with this state as the initial state. This is only called during activation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is activated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(Action<TState, T> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(
+        Action<TState, T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is activated
     ///     with this state as the initial state. This is only called during activation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is activated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(
-        Func<TState, T, CancellationToken, Task> handler
+        Func<TState, T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -50,9 +64,14 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     with this state as the initial state. This is only called during activation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is activated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(
-        Func<TState, T, CancellationToken, ValueTask> handler
+        Func<TState, T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -60,17 +79,14 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     with this state as the current state. This is only called during deactivation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(Action<TState, T> handler);
-
-    /// <summary>
-    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is deactivated
-    ///     with this state as the current state. This is only called during deactivation, not during transitions.
-    /// </summary>
-    /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(
-        Func<TState, T, CancellationToken, Task> handler
+        Action<TState, T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -78,9 +94,29 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     with this state as the current state. This is only called during deactivation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(
-        Func<TState, T, CancellationToken, ValueTask> handler
+        Func<TState, T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is deactivated
+    ///     with this state as the current state. This is only called during deactivation, not during transitions.
+    /// </summary>
+    /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(
+        Func<TState, T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -94,9 +130,14 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     </para>
     /// </summary>
     /// <param name="handler">The delegate to call as a state is changed.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnStateChange(
-        Action<TState, TTransition, TState, T> handler
+        Action<TState, TTransition, TState, T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -110,9 +151,14 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     </para>
     /// </summary>
     /// <param name="handler">The delegate to call as a state is changed.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnStateChange(
-        Func<TState, TTransition, TState, T, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -126,9 +172,14 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     </para>
     /// </summary>
     /// <param name="handler">The delegate to call as a state is changed.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterizedStateConfiguration<TState, TTransition, T> OnStateChange(
-        Func<TState, TTransition, TState, T, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -136,48 +187,90 @@ public interface IParameterizedStateConfiguration<TState, TTransition, T> : ISta
     ///     action can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is entered.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Action<T> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(
+        Action<T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is entered. This
     ///     action can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is entered.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Func<T, CancellationToken, Task> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(
+        Func<T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is entered. This
     ///     action can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is entered.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Func<T, CancellationToken, ValueTask> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(
+        Func<T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is exited. This action
     ///     can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is exited.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Action<T> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnExit(
+        Action<T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is exited. This action
     ///     can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is exited.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Func<T, CancellationToken, Task> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnExit(
+        Func<T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is exited. This action
     ///     can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is exited.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Func<T, CancellationToken, ValueTask> handler);
+    IParameterizedStateConfiguration<TState, TTransition, T> OnExit(
+        Func<T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a new action representing the main functionality of the state. This action can be interrupted by

--- a/src/ZCrew.StateCraft/States/Configuration/IParameterlessStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IParameterlessStateConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -30,25 +32,44 @@ public interface IParameterlessStateConfiguration<TState, TTransition> : IStateC
     ///     with this state as the initial state. This is only called during activation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is activated.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnActivate(Action<TState> handler);
-
-    /// <summary>
-    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is activated
-    ///     with this state as the initial state. This is only called during activation, not during transitions.
-    /// </summary>
-    /// <param name="handler">The delegate to call when the state machine is activated.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnActivate(Func<TState, CancellationToken, Task> handler);
-
-    /// <summary>
-    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is activated
-    ///     with this state as the initial state. This is only called during activation, not during transitions.
-    /// </summary>
-    /// <param name="handler">The delegate to call when the state machine is activated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterlessStateConfiguration<TState, TTransition> OnActivate(
-        Func<TState, CancellationToken, ValueTask> handler
+        Action<TState> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is activated
+    ///     with this state as the initial state. This is only called during activation, not during transitions.
+    /// </summary>
+    /// <param name="handler">The delegate to call when the state machine is activated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IParameterlessStateConfiguration<TState, TTransition> OnActivate(
+        Func<TState, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is activated
+    ///     with this state as the initial state. This is only called during activation, not during transitions.
+    /// </summary>
+    /// <param name="handler">The delegate to call when the state machine is activated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IParameterlessStateConfiguration<TState, TTransition> OnActivate(
+        Func<TState, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -56,25 +77,44 @@ public interface IParameterlessStateConfiguration<TState, TTransition> : IStateC
     ///     with this state as the current state. This is only called during deactivation, not during transitions.
     /// </summary>
     /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(Action<TState> handler);
-
-    /// <summary>
-    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is deactivated
-    ///     with this state as the current state. This is only called during deactivation, not during transitions.
-    /// </summary>
-    /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(Func<TState, CancellationToken, Task> handler);
-
-    /// <summary>
-    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is deactivated
-    ///     with this state as the current state. This is only called during deactivation, not during transitions.
-    /// </summary>
-    /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(
-        Func<TState, CancellationToken, ValueTask> handler
+        Action<TState> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is deactivated
+    ///     with this state as the current state. This is only called during deactivation, not during transitions.
+    /// </summary>
+    /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(
+        Func<TState, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="handler"/> delegate which will be called when the state machine is deactivated
+    ///     with this state as the current state. This is only called during deactivation, not during transitions.
+    /// </summary>
+    /// <param name="handler">The delegate to call when the state machine is deactivated.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(
+        Func<TState, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -87,23 +127,14 @@ public interface IParameterlessStateConfiguration<TState, TTransition> : IStateC
     ///     </para>
     /// </summary>
     /// <param name="handler">The delegate to call as a state is changed.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnStateChange(Action<TState, TTransition, TState> handler);
-
-    /// <summary>
-    ///     <para>
-    ///     Configures a <paramref name="handler"/> delegate which will be called when the state changes. The parameters
-    ///     to the <paramref name="handler"/> are: the previous state, the transition, the next state, and a token to
-    ///     monitor for cancellation.
-    ///     </para>
-    ///     <para>
-    ///     Since this is configured for a specific state, the 'next state' will always be 'this state'.
-    ///     </para>
-    /// </summary>
-    /// <param name="handler">The delegate to call as a state is changed.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterlessStateConfiguration<TState, TTransition> OnStateChange(
-        Func<TState, TTransition, TState, CancellationToken, Task> handler
+        Action<TState, TTransition, TState> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -117,9 +148,35 @@ public interface IParameterlessStateConfiguration<TState, TTransition> : IStateC
     ///     </para>
     /// </summary>
     /// <param name="handler">The delegate to call as a state is changed.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IParameterlessStateConfiguration<TState, TTransition> OnStateChange(
-        Func<TState, TTransition, TState, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     <para>
+    ///     Configures a <paramref name="handler"/> delegate which will be called when the state changes. The parameters
+    ///     to the <paramref name="handler"/> are: the previous state, the transition, the next state, and a token to
+    ///     monitor for cancellation.
+    ///     </para>
+    ///     <para>
+    ///     Since this is configured for a specific state, the 'next state' will always be 'this state'.
+    ///     </para>
+    /// </summary>
+    /// <param name="handler">The delegate to call as a state is changed.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IParameterlessStateConfiguration<TState, TTransition> OnStateChange(
+        Func<TState, TTransition, TState, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     );
 
     /// <summary>
@@ -127,48 +184,90 @@ public interface IParameterlessStateConfiguration<TState, TTransition> : IStateC
     ///     action can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is entered.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnEntry(Action handler);
+    IParameterlessStateConfiguration<TState, TTransition> OnEntry(
+        Action handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is entered. This
     ///     action can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is entered.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnEntry(Func<CancellationToken, Task> handler);
+    IParameterlessStateConfiguration<TState, TTransition> OnEntry(
+        Func<CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is entered. This
     ///     action can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is entered.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnEntry(Func<CancellationToken, ValueTask> handler);
+    IParameterlessStateConfiguration<TState, TTransition> OnEntry(
+        Func<CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is exited. This action
     ///     can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is exited.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnExit(Action handler);
+    IParameterlessStateConfiguration<TState, TTransition> OnExit(
+        Action handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is exited. This action
     ///     can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is exited.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnExit(Func<CancellationToken, Task> handler);
+    IParameterlessStateConfiguration<TState, TTransition> OnExit(
+        Func<CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="handler"/> delegate which will be called when this state is exited. This action
     ///     can not be interrupted by other state changes and should not perform state changes.
     /// </summary>
     /// <param name="handler">The delegate to call as a state is exited.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the handler. When omitted, the caller's expression for
+    ///     <paramref name="handler"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IParameterlessStateConfiguration<TState, TTransition> OnExit(Func<CancellationToken, ValueTask> handler);
+    IParameterlessStateConfiguration<TState, TTransition> OnExit(
+        Func<CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a new action representing the main functionality of the state. This action can be interrupted by

--- a/src/ZCrew.StateCraft/States/StateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
@@ -107,121 +108,152 @@ internal class StateConfiguration<TState, TTransition>
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnActivate(Action<TState> handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnActivate(
+        Action<TState> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnActivate(
-        Func<TState, CancellationToken, Task> handler
+        Func<TState, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnActivate(
-        Func<TState, CancellationToken, ValueTask> handler
+        Func<TState, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(Action<TState> handler)
-    {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(
-        Func<TState, CancellationToken, Task> handler
+        Action<TState> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(
-        Func<TState, CancellationToken, ValueTask> handler
+        Func<TState, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterlessStateConfiguration<TState, TTransition> OnDeactivate(
+        Func<TState, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnStateChange(
-        Action<TState, TTransition, TState> handler
+        Action<TState, TTransition, TState> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnStateChange(
-        Func<TState, TTransition, TState, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterlessStateConfiguration<TState, TTransition> OnStateChange(
-        Func<TState, TTransition, TState, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnEntry(Action handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnEntry(
+        Action handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnEntry(Func<CancellationToken, Task> handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnEntry(
+        Func<CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnEntry(Func<CancellationToken, ValueTask> handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnEntry(
+        Func<CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnExit(Action handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnExit(
+        Action handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnExit(Func<CancellationToken, Task> handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnExit(
+        Func<CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterlessStateConfiguration<TState, TTransition> OnExit(Func<CancellationToken, ValueTask> handler)
+    public IParameterlessStateConfiguration<TState, TTransition> OnExit(
+        Func<CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
@@ -88,132 +89,151 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnActivate(
-        Action<TState, T1, T2, T3, T4> handler
+        Action<TState, T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnActivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnActivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnDeactivate(
-        Action<TState, T1, T2, T3, T4> handler
+        Action<TState, T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnDeactivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnDeactivate(
-        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnStateChange(
-        Action<TState, TTransition, TState, T1, T2, T3, T4> handler
+        Action<TState, TTransition, TState, T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(Action<T1, T2, T3, T4> handler)
-    {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(
-        Func<T1, T2, T3, T4, CancellationToken, Task> handler
+        Action<T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(
-        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Func<T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(Action<T1, T2, T3, T4> handler)
-    {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
-        Func<T1, T2, T3, T4, CancellationToken, Task> handler
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnEntry(
+        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
-        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler
+        Action<T1, T2, T3, T4> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
+        Func<T1, T2, T3, T4, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4> OnExit(
+        Func<T1, T2, T3, T4, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
@@ -88,132 +89,151 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(
-        Action<TState, T1, T2, T3> handler
+        Action<TState, T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(
-        Func<TState, T1, T2, T3, CancellationToken, Task> handler
+        Func<TState, T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnActivate(
-        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(
-        Action<TState, T1, T2, T3> handler
+        Action<TState, T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(
-        Func<TState, T1, T2, T3, CancellationToken, Task> handler
+        Func<TState, T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnDeactivate(
-        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnStateChange(
-        Action<TState, TTransition, TState, T1, T2, T3> handler
+        Action<TState, TTransition, TState, T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(Action<T1, T2, T3> handler)
-    {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(
-        Func<T1, T2, T3, CancellationToken, Task> handler
+        Action<T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(
-        Func<T1, T2, T3, CancellationToken, ValueTask> handler
+        Func<T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(Action<T1, T2, T3> handler)
-    {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
-        Func<T1, T2, T3, CancellationToken, Task> handler
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnEntry(
+        Func<T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
-        Func<T1, T2, T3, CancellationToken, ValueTask> handler
+        Action<T1, T2, T3> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
+        Func<T1, T2, T3, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3> OnExit(
+        Func<T1, T2, T3, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
@@ -87,129 +88,152 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(Action<TState, T1, T2> handler)
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(
+        Action<TState, T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(
-        Func<TState, T1, T2, CancellationToken, Task> handler
+        Func<TState, T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnActivate(
-        Func<TState, T1, T2, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(Action<TState, T1, T2> handler)
-    {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(
-        Func<TState, T1, T2, CancellationToken, Task> handler
+        Action<TState, T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(
-        Func<TState, T1, T2, CancellationToken, ValueTask> handler
+        Func<TState, T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnDeactivate(
+        Func<TState, T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnStateChange(
-        Action<TState, TTransition, TState, T1, T2> handler
+        Action<TState, TTransition, TState, T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnStateChange(
-        Func<TState, TTransition, TState, T1, T2, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(Action<T1, T2> handler)
-    {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(
-        Func<T1, T2, CancellationToken, Task> handler
+        Action<T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(
-        Func<T1, T2, CancellationToken, ValueTask> handler
+        Func<T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(Action<T1, T2> handler)
-    {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
-        Func<T1, T2, CancellationToken, Task> handler
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnEntry(
+        Func<T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
-        Func<T1, T2, CancellationToken, ValueTask> handler
+        Action<T1, T2> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
+        Func<T1, T2, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T1, T2> OnExit(
+        Func<T1, T2, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
@@ -92,125 +93,152 @@ internal class StateConfiguration<TState, TTransition, T>
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(Action<TState, T> handler)
+    public IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(
+        Action<TState, T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(
-        Func<TState, T, CancellationToken, Task> handler
+        Func<TState, T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnActivate(
-        Func<TState, T, CancellationToken, ValueTask> handler
+        Func<TState, T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(Action<TState, T> handler)
-    {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onActivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(
-        Func<TState, T, CancellationToken, Task> handler
+        Action<TState, T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(
-        Func<TState, T, CancellationToken, ValueTask> handler
+        Func<TState, T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T> OnDeactivate(
+        Func<TState, T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onDeactivateHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnStateChange(
-        Action<TState, TTransition, TState, T> handler
+        Action<TState, TTransition, TState, T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnStateChange(
-        Func<TState, TTransition, TState, T, CancellationToken, Task> handler
+        Func<TState, TTransition, TState, T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnStateChange(
-        Func<TState, TTransition, TState, T, CancellationToken, ValueTask> handler
+        Func<TState, TTransition, TState, T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Action<T> handler)
-    {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(Func<T, CancellationToken, Task> handler)
-    {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onStateChangeHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(
-        Func<T, CancellationToken, ValueTask> handler
+        Action<T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Action<T> handler)
+    public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(
+        Func<T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(Func<T, CancellationToken, Task> handler)
+    public IParameterizedStateConfiguration<TState, TTransition, T> OnEntry(
+        Func<T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onEntryHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(
-        Func<T, CancellationToken, ValueTask> handler
+        Action<T> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
     )
     {
-        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler());
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(
+        Func<T, CancellationToken, Task> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IParameterizedStateConfiguration<TState, TTransition, T> OnExit(
+        Func<T, CancellationToken, ValueTask> handler,
+        [CallerArgumentExpression(nameof(handler))] string? descriptor = null
+    )
+    {
+        this.onExitHandlers.Add(handler.AsAsyncAction().AsAsyncHandler(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -14,7 +16,7 @@ namespace ZCrew.StateCraft;
 /// </typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -31,22 +33,43 @@ public interface IDirectTransitionConfiguration<TState, TTransition>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IDirectTransitionConfiguration<TState, TTransition> If(Func<bool> condition);
+    IDirectTransitionConfiguration<TState, TTransition> If(
+        Func<bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IDirectTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, Task<bool>> condition);
+    IDirectTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IDirectTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, ValueTask<bool>> condition);
+    IDirectTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configure the state to transition to.

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext1,TNext2,TNext3,TNext4}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext1,TNext2,TNext3,TNext4}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -18,8 +20,8 @@ namespace ZCrew.StateCraft;
 /// <typeparam name="TNext4">The type of the fourth parameter for the next state.</typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{TNext1, TNext2, TNext3, TNext4, bool})"/> are evaluated in the order they are
-///     registered. All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
+///     Conditions added via <see cref="If(Func{TNext1, TNext2, TNext3, TNext4, bool}, string?)"/> are evaluated in the order
+///     they are registered. All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
 ///     <para>
@@ -36,9 +38,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, bool> condition
+        Func<TNext1, TNext2, TNext3, TNext4, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>
@@ -46,9 +53,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>
@@ -56,9 +68,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext1,TNext2,TNext3}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext1,TNext2,TNext3}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -17,7 +19,7 @@ namespace ZCrew.StateCraft;
 /// <typeparam name="TNext3">The type of the third parameter for the next state.</typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{TNext1, TNext2, TNext3, bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{TNext1, TNext2, TNext3, bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -35,9 +37,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, bool> condition
+        Func<TNext1, TNext2, TNext3, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>
@@ -45,9 +52,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>
@@ -55,9 +67,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext1,TNext2}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext1,TNext2}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -16,7 +18,7 @@ namespace ZCrew.StateCraft;
 /// <typeparam name="TNext2">The type of the second parameter for the next state.</typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{TNext1, TNext2, bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{TNext1, TNext2, bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -34,17 +36,14 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(Func<TNext1, TNext2, bool> condition);
-
-    /// <summary>
-    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
-    ///     The condition receives the transition parameter values that will be passed to the next state.
-    /// </summary>
-    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>
@@ -52,9 +51,29 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext1, TNe
     ///     The condition receives the transition parameter values that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
+    ///     The condition receives the transition parameter values that will be passed to the next state.
+    /// </summary>
+    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
+        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IDirectTransitionConfiguration{TNext}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -16,7 +18,7 @@ namespace ZCrew.StateCraft;
 /// <typeparam name="TNext">The type of the parameter for the next state.</typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{TNext, bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{TNext, bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -34,25 +36,44 @@ public interface IDirectTransitionConfiguration<TState, TTransition, TNext>
     ///     The condition receives the transition parameter value that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IDirectTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, bool> condition);
-
-    /// <summary>
-    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
-    ///     The condition receives the transition parameter value that will be passed to the next state.
-    /// </summary>
-    /// <param name="condition">The delegate to check when resolving the transition.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IDirectTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, CancellationToken, Task<bool>> condition);
-
-    /// <summary>
-    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
-    ///     The condition receives the transition parameter value that will be passed to the next state.
-    /// </summary>
-    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IDirectTransitionConfiguration<TState, TTransition, TNext> If(
-        Func<TNext, CancellationToken, ValueTask<bool>> condition
+        Func<TNext, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
+    ///     The condition receives the transition parameter value that will be passed to the next state.
+    /// </summary>
+    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IDirectTransitionConfiguration<TState, TTransition, TNext> If(
+        Func<TNext, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
+    ///     The condition receives the transition parameter value that will be passed to the next state.
+    /// </summary>
+    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IDirectTransitionConfiguration<TState, TTransition, TNext> If(
+        Func<TNext, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -14,7 +16,7 @@ namespace ZCrew.StateCraft;
 /// </typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -31,22 +33,43 @@ public interface IInitialTransitionConfiguration<TState, TTransition>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IInitialTransitionConfiguration<TState, TTransition> If(Func<bool> condition);
+    IInitialTransitionConfiguration<TState, TTransition> If(
+        Func<bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IInitialTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, Task<bool>> condition);
+    IInitialTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IInitialTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, ValueTask<bool>> condition);
+    IInitialTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures the transition to have no parameters. This is optional and is implied if no parameter

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T1,T2,T3,T4}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -20,17 +22,22 @@ public interface IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,bool})"/>
-    IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(Func<T1, T2, T3, T4, bool> condition);
-
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,Task{bool}})"/>
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,bool}, string?)"/>
     IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(
-        Func<T1, T2, T3, T4, CancellationToken, Task<bool>> condition
+        Func<T1, T2, T3, T4, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,ValueTask{bool}})"/>
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,Task{bool}}, string?)"/>
     IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(
-        Func<T1, T2, T3, T4, CancellationToken, ValueTask<bool>> condition
+        Func<T1, T2, T3, T4, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,ValueTask{bool}}, string?)"/>
+    IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(
+        Func<T1, T2, T3, T4, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.WithNoParameters"/>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T1,T2,T3}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -19,17 +21,22 @@ public interface IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,bool})"/>
-    IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(Func<T1, T2, T3, bool> condition);
-
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,Task{bool}})"/>
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,bool}, string?)"/>
     IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(
-        Func<T1, T2, T3, CancellationToken, Task<bool>> condition
+        Func<T1, T2, T3, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,ValueTask{bool}})"/>
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,Task{bool}}, string?)"/>
     IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(
-        Func<T1, T2, T3, CancellationToken, ValueTask<bool>> condition
+        Func<T1, T2, T3, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,ValueTask{bool}}, string?)"/>
+    IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(
+        Func<T1, T2, T3, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.WithNoParameters"/>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T1,T2}.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -18,17 +20,22 @@ public interface IInitialTransitionConfiguration<TState, TTransition, T1, T2>
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,bool})"/>
-    IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(Func<T1, T2, bool> condition);
-
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,Task{bool}})"/>
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,bool}, string?)"/>
     IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(
-        Func<T1, T2, CancellationToken, Task<bool>> condition
+        Func<T1, T2, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,ValueTask{bool}})"/>
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,Task{bool}}, string?)"/>
     IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(
-        Func<T1, T2, CancellationToken, ValueTask<bool>> condition
+        Func<T1, T2, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.If(Func{TPrevious,CancellationToken,ValueTask{bool}}, string?)"/>
+    IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(
+        Func<T1, T2, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IInitialTransitionConfiguration{TState,TTransition,TPrevious}.WithNoParameters"/>

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IInitialTransitionConfiguration{T}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.StateCraft.StateMachines.Contracts;
 
 namespace ZCrew.StateCraft;
@@ -17,7 +18,7 @@ namespace ZCrew.StateCraft;
 /// <typeparam name="T">The type of the parameter for the previous state.</typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{T, bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{T, bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -35,24 +36,45 @@ public interface IInitialTransitionConfiguration<TState, TTransition, T>
     ///     The condition receives the previous state's parameter value.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, bool> condition);
+    IInitialTransitionConfiguration<TState, TTransition, T> If(
+        Func<T, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     ///     The condition receives the previous state's parameter value.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, CancellationToken, Task<bool>> condition);
+    IInitialTransitionConfiguration<TState, TTransition, T> If(
+        Func<T, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
     ///     The condition receives the previous state's parameter value.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, CancellationToken, ValueTask<bool>> condition);
+    IInitialTransitionConfiguration<TState, TTransition, T> If(
+        Func<T, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
 
     /// <summary>
     ///     Configures the transition to have no parameters. This is optional and is implied if no parameter

--- a/src/ZCrew.StateCraft/Transitions/Configuration/IMappedTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/Configuration/IMappedTransitionConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ZCrew.StateCraft;
 
 /// <summary>
@@ -16,7 +18,7 @@ namespace ZCrew.StateCraft;
 /// <typeparam name="TNext">The type of the mapped parameter for the next state.</typeparam>
 /// <remarks>
 ///     <para>
-///     Conditions added via <see cref="If(Func{TNext, bool})"/> are evaluated in the order they are registered.
+///     Conditions added via <see cref="If(Func{TNext, bool}, string?)"/> are evaluated in the order they are registered.
 ///     All conditions must return <see langword="true"/> for the transition to proceed (logical AND).
 ///     Evaluation short-circuits on the first <see langword="false"/> result.
 ///     </para>
@@ -34,25 +36,44 @@ public interface IMappedTransitionConfiguration<TState, TTransition, TNext>
     ///     The condition receives the mapped parameter value from the previous that will be passed to the next state.
     /// </summary>
     /// <param name="condition">The delegate to check when resolving the transition.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IMappedTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, bool> condition);
-
-    /// <summary>
-    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
-    ///     The condition receives the mapped parameter value from the previous that will be passed to the next state.
-    /// </summary>
-    /// <param name="condition">The delegate to check when resolving the transition.</param>
-    /// <returns>A reference to the configuration after the configuration was updated.</returns>
-    IMappedTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, CancellationToken, Task<bool>> condition);
-
-    /// <summary>
-    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
-    ///     The condition receives the mapped parameter value from the previous that will be passed to the next state.
-    /// </summary>
-    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
     /// <returns>A reference to the configuration after the configuration was updated.</returns>
     IMappedTransitionConfiguration<TState, TTransition, TNext> If(
-        Func<TNext, CancellationToken, ValueTask<bool>> condition
+        Func<TNext, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
+    ///     The condition receives the mapped parameter value from the previous that will be passed to the next state.
+    /// </summary>
+    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IMappedTransitionConfiguration<TState, TTransition, TNext> If(
+        Func<TNext, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <summary>
+    ///     Configures a <paramref name="condition"/> which will be evaluated when resolving which transition to use.
+    ///     The condition receives the mapped parameter value from the previous that will be passed to the next state.
+    /// </summary>
+    /// <param name="condition">The delegate to check when resolving the transition.</param>
+    /// <param name="descriptor">
+    ///     An optional descriptor identifying the condition. When omitted, the caller's expression for
+    ///     <paramref name="condition"/> is captured automatically.
+    /// </param>
+    /// <returns>A reference to the configuration after the configuration was updated.</returns>
+    IMappedTransitionConfiguration<TState, TTransition, TNext> If(
+        Func<TNext, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <summary>
@@ -91,17 +112,22 @@ public interface IMappedTransitionConfiguration<TState, TTransition, TNext1, TNe
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,bool})"/>
-    IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(Func<TNext1, TNext2, bool> condition);
-
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,Task{bool}})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,bool}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,ValueTask{bool}})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,Task{bool}}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    );
+
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,ValueTask{bool}}, string?)"/>
+    IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
+        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.To"/>
@@ -129,19 +155,22 @@ public interface IMappedTransitionConfiguration<TState, TTransition, TNext1, TNe
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,bool})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,bool}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, bool> condition
+        Func<TNext1, TNext2, TNext3, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,Task{bool}})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,Task{bool}}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,ValueTask{bool}})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,ValueTask{bool}}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.To"/>
@@ -170,19 +199,22 @@ public interface IMappedTransitionConfiguration<TState, TTransition, TNext1, TNe
     where TState : notnull
     where TTransition : notnull
 {
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,bool})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,bool}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, bool> condition
+        Func<TNext1, TNext2, TNext3, TNext4, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,Task{bool}})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,Task{bool}}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
-    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,ValueTask{bool}})"/>
+    /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.If(Func{TNext,CancellationToken,ValueTask{bool}}, string?)"/>
     IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     );
 
     /// <inheritdoc cref="IMappedTransitionConfiguration{TState,TTransition,TNext}.To"/>

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
@@ -34,23 +35,32 @@ internal class InitialTransitionConfiguration<TState, TTransition>
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition> If(Func<bool> condition)
+    public IInitialTransitionConfiguration<TState, TTransition> If(
+        Func<bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, Task<bool>> condition)
+    public IInitialTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, ValueTask<bool>> condition)
+    public IInitialTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3,T4}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
@@ -30,27 +31,32 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(Func<T1, T2, T3, T4, bool> condition)
+    public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(
+        Func<T1, T2, T3, T4, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(
-        Func<T1, T2, T3, T4, CancellationToken, Task<bool>> condition
+        Func<T1, T2, T3, T4, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3, T4> If(
-        Func<T1, T2, T3, T4, CancellationToken, ValueTask<bool>> condition
+        Func<T1, T2, T3, T4, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2,T3}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
@@ -30,27 +31,32 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2, T3>
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(Func<T1, T2, T3, bool> condition)
+    public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(
+        Func<T1, T2, T3, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(
-        Func<T1, T2, T3, CancellationToken, Task<bool>> condition
+        Func<T1, T2, T3, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2, T3> If(
-        Func<T1, T2, T3, CancellationToken, ValueTask<bool>> condition
+        Func<T1, T2, T3, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T1,T2}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
@@ -28,27 +29,32 @@ internal class InitialTransitionConfiguration<TState, TTransition, T1, T2>
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(Func<T1, T2, bool> condition)
+    public IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(
+        Func<T1, T2, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(
-        Func<T1, T2, CancellationToken, Task<bool>> condition
+        Func<T1, T2, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T1, T2> If(
-        Func<T1, T2, CancellationToken, ValueTask<bool>> condition
+        Func<T1, T2, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/Transitions/InitialTransitionConfiguration{T}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping;
@@ -35,25 +36,32 @@ internal class InitialTransitionConfiguration<TState, TTransition, T>
     }
 
     /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, bool> condition)
+    public IInitialTransitionConfiguration<TState, TTransition, T> If(
+        Func<T, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IInitialTransitionConfiguration<TState, TTransition, T> If(Func<T, CancellationToken, Task<bool>> condition)
-    {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IInitialTransitionConfiguration<TState, TTransition, T> If(
-        Func<T, CancellationToken, ValueTask<bool>> condition
+        Func<T, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IInitialTransitionConfiguration<TState, TTransition, T> If(
+        Func<T, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
+    {
+        this.previousStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
@@ -48,23 +49,32 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition>
     }
 
     /// <inheritdoc />
-    public IDirectTransitionConfiguration<TState, TTransition> If(Func<bool> condition)
+    public IDirectTransitionConfiguration<TState, TTransition> If(
+        Func<bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IDirectTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, Task<bool>> condition)
+    public IDirectTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
-    public IDirectTransitionConfiguration<TState, TTransition> If(Func<CancellationToken, ValueTask<bool>> condition)
+    public IDirectTransitionConfiguration<TState, TTransition> If(
+        Func<CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3,TNext4}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3,TNext4}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
@@ -57,28 +58,31 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, bool> condition
+        Func<TNext1, TNext2, TNext3, TNext4, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2,TNext3}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
@@ -49,28 +50,31 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, bool> condition
+        Func<TNext1, TNext2, TNext3, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext1,TNext2}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
@@ -48,27 +49,32 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext1,
     }
 
     /// <inheritdoc />
-    public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(Func<TNext1, TNext2, bool> condition)
+    public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
+        Func<TNext1, TNext2, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext}.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialDirectTransitionConfiguration{TNext}.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.States;
@@ -48,27 +49,32 @@ internal class PartialDirectTransitionConfiguration<TState, TTransition, TNext>
     }
 
     /// <inheritdoc />
-    public IDirectTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, bool> condition)
+    public IDirectTransitionConfiguration<TState, TTransition, TNext> If(
+        Func<TNext, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext> If(
-        Func<TNext, CancellationToken, Task<bool>> condition
+        Func<TNext, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IDirectTransitionConfiguration<TState, TTransition, TNext> If(
-        Func<TNext, CancellationToken, ValueTask<bool>> condition
+        Func<TNext, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 

--- a/src/ZCrew.StateCraft/Transitions/PartialMappedTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/PartialMappedTransitionConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Extensions;
 using ZCrew.StateCraft.Mapping.Contracts;
@@ -54,27 +55,32 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext>
     }
 
     /// <inheritdoc />
-    public IMappedTransitionConfiguration<TState, TTransition, TNext> If(Func<TNext, bool> condition)
+    public IMappedTransitionConfiguration<TState, TTransition, TNext> If(
+        Func<TNext, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext> If(
-        Func<TNext, CancellationToken, Task<bool>> condition
+        Func<TNext, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext> If(
-        Func<TNext, CancellationToken, ValueTask<bool>> condition
+        Func<TNext, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
@@ -133,27 +139,32 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
     }
 
     /// <inheritdoc />
-    public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(Func<TNext1, TNext2, bool> condition)
+    public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
+        Func<TNext1, TNext2, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
+    )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2> If(
-        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
@@ -213,28 +224,31 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, bool> condition
+        Func<TNext1, TNext2, TNext3, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3> If(
-        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
@@ -302,28 +316,31 @@ internal class PartialMappedTransitionConfiguration<TState, TTransition, TNext1,
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, bool> condition
+        Func<TNext1, TNext2, TNext3, TNext4, bool> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, Task<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 
     /// <inheritdoc />
     public IMappedTransitionConfiguration<TState, TTransition, TNext1, TNext2, TNext3, TNext4> If(
-        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition
+        Func<TNext1, TNext2, TNext3, TNext4, CancellationToken, ValueTask<bool>> condition,
+        [CallerArgumentExpression(nameof(condition))] string? descriptor = null
     )
     {
-        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition());
+        this.nextStateConfiguration.Add(condition.AsAsyncFunc().AsAsyncCondition(descriptor));
         return this;
     }
 


### PR DESCRIPTION
Adds a descriptor to delegates, defaulting to the argument expression using `CallerArgumentExpression`.

This is currently unused so no testing could be added.

Closes #155