### PR TITLE
#159 - Add rendering to the state machine components

### DIFF
--- a/src/ZCrew.StateCraft/Rendering/Contracts/IRenderable.cs
+++ b/src/ZCrew.StateCraft/Rendering/Contracts/IRenderable.cs
@@ -1,0 +1,17 @@
+namespace ZCrew.StateCraft.Rendering.Contracts;
+
+/// <summary>
+///     Represents a type that has meaningful information to add to a rendering context.
+/// </summary>
+/// <typeparam name="TState">The type of the state.</typeparam>
+/// <typeparam name="TTransition">The type of the transition.</typeparam>
+internal interface IRenderable<TState, TTransition>
+    where TState : notnull
+    where TTransition : notnull
+{
+    /// <summary>
+    ///     Add information to the rendering context to perform rendering, such as exporting to a mermaid diagram.
+    /// </summary>
+    /// <param name="context">The rendering context to add to.</param>
+    void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context);
+}

--- a/src/ZCrew.StateCraft/Rendering/Contracts/IRenderableConditions.cs
+++ b/src/ZCrew.StateCraft/Rendering/Contracts/IRenderableConditions.cs
@@ -1,0 +1,17 @@
+namespace ZCrew.StateCraft.Rendering.Contracts;
+
+/// <summary>
+///     Represents a type that has meaningful information about conditional rendering components.
+/// </summary>
+internal interface IRenderableConditions
+{
+    /// <summary>
+    ///     Return human-readable descriptors for each condition that gates the component, used to label the conditional
+    ///     component when it is rendered.
+    /// </summary>
+    /// <returns>
+    ///     One descriptor per condition, in the order the conditions were registered. Empty when the component is
+    ///     unconditional.
+    /// </returns>
+    IEnumerable<string> RenderConditions();
+}

--- a/src/ZCrew.StateCraft/Rendering/Extensions/TypeExtensions.cs
+++ b/src/ZCrew.StateCraft/Rendering/Extensions/TypeExtensions.cs
@@ -8,11 +8,12 @@ internal static class TypeExtensions
     extension(Type type)
     {
         /// <summary>
-        ///     A stable identifier for the type suitable for use as a node id in a rendered diagram. Returns
-        ///     <see cref="Type.FullName"/> when available and falls back to <see cref="System.Reflection.MemberInfo.Name"/>
-        ///     for types that do not expose a full name (for example, generic type parameters).
+        ///     A stable identifier for the type suitable for use as a node identifier in a rendered diagram. Returns
+        ///     <see cref="Type.FullName"/> when available and falls back to
+        ///     <see cref="System.Reflection.MemberInfo.Name"/> for types that do not expose a full name (for example,
+        ///     generic type parameters).
         /// </summary>
-        public string RenderingId
+        public string RenderingIdentifier
         {
             get { return type.FullName ?? type.Name; }
         }

--- a/src/ZCrew.StateCraft/Rendering/Extensions/TypeExtensions.cs
+++ b/src/ZCrew.StateCraft/Rendering/Extensions/TypeExtensions.cs
@@ -1,0 +1,20 @@
+namespace ZCrew.StateCraft.Rendering.Extensions;
+
+/// <summary>
+///     Rendering helpers exposed on <see cref="Type"/>.
+/// </summary>
+internal static class TypeExtensions
+{
+    extension(Type type)
+    {
+        /// <summary>
+        ///     A stable identifier for the type suitable for use as a node id in a rendered diagram. Returns
+        ///     <see cref="Type.FullName"/> when available and falls back to <see cref="System.Reflection.MemberInfo.Name"/>
+        ///     for types that do not expose a full name (for example, generic type parameters).
+        /// </summary>
+        public string RenderingId
+        {
+            get { return type.FullName ?? type.Name; }
+        }
+    }
+}

--- a/src/ZCrew.StateCraft/Rendering/Models/StateMachineRenderingModel.cs
+++ b/src/ZCrew.StateCraft/Rendering/Models/StateMachineRenderingModel.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ZCrew.StateCraft.Rendering.Models;
+
+/// <summary>
+///     The top-level rendering description of a state machine. Sits alongside the per-state and per-transition models in
+///     a <see cref="StateMachineRenderingContext{TState, TTransition}"/> and supplies the labelling for the diagram as a
+///     whole.
+/// </summary>
+/// <typeparam name="TState">The type of the state.</typeparam>
+/// <typeparam name="TTransition">The type of the transition.</typeparam>
+internal sealed class StateMachineRenderingModel<TState, TTransition>
+    where TState : notnull
+    where TTransition : notnull
+{
+    /// <summary>
+    ///     Initializes a new <see cref="StateMachineRenderingModel{TState, TTransition}"/>.
+    /// </summary>
+    /// <param name="descriptor">The human-readable display string for the state machine itself.</param>
+    [SetsRequiredMembers]
+    public StateMachineRenderingModel(string descriptor)
+    {
+        Descriptor = descriptor;
+    }
+
+    /// <summary>
+    ///     The display string for the state machine itself, used for example as the title of the rendered diagram.
+    /// </summary>
+    public required string Descriptor { get; init; }
+}

--- a/src/ZCrew.StateCraft/Rendering/Models/StateRenderingModel.cs
+++ b/src/ZCrew.StateCraft/Rendering/Models/StateRenderingModel.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ZCrew.StateCraft.Rendering.Models;
+
+/// <summary>
+///     The renderable view of a single state in a state machine. Captures both the underlying state value and the
+///     identifier and display string that a renderer (Mermaid, GraphViz, etc.) needs to draw and reference the state.
+/// </summary>
+/// <typeparam name="TState">The type of the state.</typeparam>
+/// <typeparam name="TTransition">The type of the transition.</typeparam>
+internal sealed class StateRenderingModel<TState, TTransition>
+    where TState : notnull
+    where TTransition : notnull
+{
+    /// <summary>
+    ///     Initializes a new <see cref="StateRenderingModel{TState, TTransition}"/>.
+    /// </summary>
+    /// <param name="state">The state value.</param>
+    /// <param name="typeParameters">The type parameters of the state, in declaration order; empty for parameterless states.</param>
+    /// <param name="name">The stable identifier used to reference the state from transitions.</param>
+    /// <param name="descriptor">The human-readable display string for the state.</param>
+    [SetsRequiredMembers]
+    public StateRenderingModel(TState state, IReadOnlyList<Type> typeParameters, string name, string descriptor)
+    {
+        State = state;
+        TypeParameters = typeParameters;
+        Name = name;
+        Descriptor = descriptor;
+    }
+
+    /// <summary>
+    ///     The state value.
+    /// </summary>
+    public required TState State { get; init; }
+
+    /// <summary>
+    ///     The type parameters of the state.
+    /// </summary>
+    public required IReadOnlyList<Type> TypeParameters { get; init; }
+
+    /// <summary>
+    ///     The stable identifier used to reference this state from transitions. Built from the state value plus its type
+    ///     parameters so that two parameterized states sharing the same underlying value but different parameter types
+    ///     produce distinct ids.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///     The human-readable display string for the state — the <see cref="object.ToString"/> form, which includes the
+    ///     type parameters for parameterized states.
+    /// </summary>
+    public required string Descriptor { get; init; }
+}

--- a/src/ZCrew.StateCraft/Rendering/Models/StateRenderingModel.cs
+++ b/src/ZCrew.StateCraft/Rendering/Models/StateRenderingModel.cs
@@ -17,14 +17,14 @@ internal sealed class StateRenderingModel<TState, TTransition>
     /// </summary>
     /// <param name="state">The state value.</param>
     /// <param name="typeParameters">The type parameters of the state, in declaration order; empty for parameterless states.</param>
-    /// <param name="name">The stable identifier used to reference the state from transitions.</param>
+    /// <param name="identifier">The stable identifier used to reference the state from transitions.</param>
     /// <param name="descriptor">The human-readable display string for the state.</param>
     [SetsRequiredMembers]
-    public StateRenderingModel(TState state, IReadOnlyList<Type> typeParameters, string name, string descriptor)
+    public StateRenderingModel(TState state, IReadOnlyList<Type> typeParameters, string identifier, string descriptor)
     {
         State = state;
         TypeParameters = typeParameters;
-        Name = name;
+        Identifier = identifier;
         Descriptor = descriptor;
     }
 
@@ -43,7 +43,7 @@ internal sealed class StateRenderingModel<TState, TTransition>
     ///     parameters so that two parameterized states sharing the same underlying value but different parameter types
     ///     produce distinct ids.
     /// </summary>
-    public required string Name { get; init; }
+    public required string Identifier { get; init; }
 
     /// <summary>
     ///     The human-readable display string for the state — the <see cref="object.ToString"/> form, which includes the

--- a/src/ZCrew.StateCraft/Rendering/Models/TransitionRenderingModel.cs
+++ b/src/ZCrew.StateCraft/Rendering/Models/TransitionRenderingModel.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ZCrew.StateCraft.Rendering.Models;
+
+/// <summary>
+///     The renderable view of a single transition between two states.
+/// </summary>
+/// <typeparam name="TState">The type of the state.</typeparam>
+/// <typeparam name="TTransition">The type of the transition.</typeparam>
+internal sealed class TransitionRenderingModel<TState, TTransition>
+    where TState : notnull
+    where TTransition : notnull
+{
+    /// <summary>
+    ///     Initializes a new <see cref="TransitionRenderingModel{TState, TTransition}"/>.
+    /// </summary>
+    /// <param name="descriptor">The display label for the transition.</param>
+    /// <param name="conditions">The descriptors of the conditions that gate the transition.</param>
+    [SetsRequiredMembers]
+    public TransitionRenderingModel(string descriptor, IReadOnlyList<string> conditions)
+    {
+        Descriptor = descriptor;
+        Conditions = conditions;
+    }
+
+    /// <summary>
+    ///     The display label for the transition — typically the <see cref="object.ToString"/> form of the trigger value.
+    /// </summary>
+    public required string Descriptor { get; init; }
+
+    /// <summary>
+    ///     The descriptors of the conditions that gate the transition, gathered in order from the previous-state and
+    ///     next-state configurations. Empty when the transition is unconditional.
+    /// </summary>
+    public required IReadOnlyList<string> Conditions { get; init; }
+}

--- a/src/ZCrew.StateCraft/Rendering/StateMachineRenderingContext.cs
+++ b/src/ZCrew.StateCraft/Rendering/StateMachineRenderingContext.cs
@@ -1,0 +1,68 @@
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Models;
+
+namespace ZCrew.StateCraft.Rendering;
+
+/// <summary>
+///     A mutable accumulator that <see cref="IRenderable{TState, TTransition}"/> implementations write into while a state
+///     machine configuration tree is walked. Once populated, the collected models describe the full structure that a
+///     renderer needs to produce a diagram.
+/// </summary>
+/// <typeparam name="TState">The type of the state.</typeparam>
+/// <typeparam name="TTransition">The type of the transition.</typeparam>
+internal sealed class StateMachineRenderingContext<TState, TTransition>
+    where TState : notnull
+    where TTransition : notnull
+{
+    /// <summary>
+    ///     The top-level model describing the state machine itself. Populated by the configuration during
+    ///     <see cref="AddToRenderingContext(IStateMachineConfiguration{TState, TTransition})"/>; <see langword="null"/>
+    ///     until then.
+    /// </summary>
+    public StateMachineRenderingModel<TState, TTransition>? StateMachine { get; set; }
+
+    /// <summary>
+    ///     The collected state models, in the order they were added by the configuration walk.
+    /// </summary>
+    public List<StateRenderingModel<TState, TTransition>> States { get; } = [];
+
+    /// <summary>
+    ///     The collected transition models, in the order they were added by the configuration walk.
+    /// </summary>
+    public List<TransitionRenderingModel<TState, TTransition>> Transitions { get; } = [];
+
+    /// <summary>
+    ///     Walks the supplied configuration and populates this context. The state machine itself is added first, then
+    ///     every state, then every transition — that order ensures all <see cref="States"/> are present before any
+    ///     transition model is built, which is required to support one-to-many, many-to-one, and many-to-many transition
+    ///     shapes.
+    /// </summary>
+    /// <param name="stateMachineConfiguration">The configuration to render.</param>
+    public void AddToRenderingContext(IStateMachineConfiguration<TState, TTransition> stateMachineConfiguration)
+    {
+        if (stateMachineConfiguration is IRenderable<TState, TTransition> renderableConfiguration)
+        {
+            renderableConfiguration.AddToRenderingContext(this);
+        }
+
+        var states = stateMachineConfiguration.States;
+        var transitions = stateMachineConfiguration.States.SelectMany(state => state.Transitions);
+
+        // To accomodate transitions that are one-to-many, many-to-one, or many-to-many, add the states first and then
+        // the transitions. This ensures all states are present when creating the transition models
+        foreach (var state in states)
+        {
+            if (state is IRenderable<TState, TTransition> renderable)
+            {
+                renderable.AddToRenderingContext(this);
+            }
+        }
+        foreach (var transition in transitions)
+        {
+            if (transition is IRenderable<TState, TTransition> renderable)
+            {
+                renderable.AddToRenderingContext(this);
+            }
+        }
+    }
+}

--- a/src/ZCrew.StateCraft/StateMachines/StateMachineConfiguration.cs
+++ b/src/ZCrew.StateCraft/StateMachines/StateMachineConfiguration.cs
@@ -1,4 +1,7 @@
 using ZCrew.Extensions.Tasks;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.Triggers;
@@ -7,8 +10,10 @@ using ZCrew.StateCraft.Validation;
 
 namespace ZCrew.StateCraft.StateMachines;
 
-/// <inheritdoc/>
-internal class StateMachineConfiguration<TState, TTransition> : IStateMachineConfiguration<TState, TTransition>
+/// <inheritdoc cref="IStateMachineConfiguration{TState,TTransition}" />
+internal class StateMachineConfiguration<TState, TTransition>
+    : IStateMachineConfiguration<TState, TTransition>,
+        IRenderable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
@@ -432,6 +437,13 @@ internal class StateMachineConfiguration<TState, TTransition> : IStateMachineCon
         var triggerConfiguration = configureTrigger(initialTriggerConfiguration);
         this.triggerConfigurations.Add(triggerConfiguration);
         return this;
+    }
+
+    /// <inheritdoc/>
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        const string descriptor = "State Machine";
+        context.StateMachine = new StateMachineRenderingModel<TState, TTransition>(descriptor);
     }
 
     private IExceptionBehavior BuildExceptionBehavior()

--- a/src/ZCrew.StateCraft/States/Configuration/INextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/INextStateConfiguration.cs
@@ -1,3 +1,4 @@
+using ZCrew.StateCraft.Rendering.Contracts;
 using ZCrew.StateCraft.States.Contracts;
 
 namespace ZCrew.StateCraft.States.Configuration;
@@ -13,7 +14,7 @@ namespace ZCrew.StateCraft.States.Configuration;
 ///     The transition type. This should be an <see langword="enum"/> type or it should be an equatable type so the
 ///     state machine behaves as expected.
 /// </typeparam>
-internal interface INextStateConfiguration<TState, TTransition>
+internal interface INextStateConfiguration<TState, TTransition> : IRenderableConditions
     where TState : notnull
     where TTransition : notnull
 {

--- a/src/ZCrew.StateCraft/States/Configuration/IPreviousStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IPreviousStateConfiguration.cs
@@ -1,3 +1,4 @@
+using ZCrew.StateCraft.Rendering.Contracts;
 using ZCrew.StateCraft.States.Contracts;
 
 namespace ZCrew.StateCraft.States.Configuration;
@@ -13,7 +14,7 @@ namespace ZCrew.StateCraft.States.Configuration;
 ///     The transition type. This should be an <see langword="enum"/> type or it should be an equatable type so the
 ///     state machine behaves as expected.
 /// </typeparam>
-internal interface IPreviousStateConfiguration<TState, TTransition>
+internal interface IPreviousStateConfiguration<TState, TTransition> : IRenderableConditions
     where TState : notnull
     where TTransition : notnull
 {

--- a/src/ZCrew.StateCraft/States/NextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/NextStateConfiguration.cs
@@ -50,6 +50,17 @@ internal class NextStateConfiguration<TState, TTransition> : INextStateConfigura
     }
 
     /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}";
@@ -100,6 +111,17 @@ internal class NextStateConfiguration<TState, TTransition, T> : INextStateConfig
     {
         var state = stateTable.LookupState<T>(StateValue);
         return new NextState<TState, TTransition, T>(state, this.conditions);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
     }
 
     /// <inheritdoc />
@@ -155,6 +177,17 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2> : INextStateC
     {
         var state = stateTable.LookupState<T1, T2>(StateValue);
         return new NextState<TState, TTransition, T1, T2>(state, this.conditions);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
     }
 
     /// <inheritdoc />
@@ -214,6 +247,17 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3> : INextSt
     }
 
     /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}<{typeof(T1).FriendlyName}, {typeof(T2).FriendlyName}, {typeof(T3).FriendlyName}>";
@@ -269,6 +313,17 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3, T4>
     {
         var state = stateTable.LookupState<T1, T2, T3, T4>(StateValue);
         return new NextState<TState, TTransition, T1, T2, T3, T4>(state, this.conditions);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
     }
 
     /// <inheritdoc />

--- a/src/ZCrew.StateCraft/States/PreviousStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/PreviousStateConfiguration.cs
@@ -60,6 +60,17 @@ internal class PreviousStateConfiguration<TState, TTransition> : IPartialPreviou
     }
 
     /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}";
@@ -122,6 +133,17 @@ internal class PreviousStateConfiguration<TState, TTransition, T>
     public void Add(AsyncCondition<T> condition)
     {
         this.conditions.Add(condition);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
     }
 
     /// <inheritdoc />
@@ -188,6 +210,17 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2>
     public void Add(AsyncCondition<T1, T2> condition)
     {
         this.conditions.Add(condition);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
     }
 
     /// <inheritdoc />
@@ -258,6 +291,17 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3>
     }
 
     /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}<{typeof(T1).FriendlyName}, {typeof(T2).FriendlyName}, {typeof(T3).FriendlyName}>";
@@ -323,6 +367,17 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3, T4>
     public void Add(AsyncCondition<T1, T2, T3, T4> condition)
     {
         this.conditions.Add(condition);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RenderConditions()
+    {
+        if (!IsConditional)
+        {
+            return [];
+        }
+
+        return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
     }
 
     /// <inheritdoc />

--- a/src/ZCrew.StateCraft/States/StateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration.cs
@@ -301,9 +301,9 @@ internal class StateConfiguration<TState, TTransition>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var id = $"{State}";
+        var identifier = $"{State}";
         var descriptor = ToString();
-        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, identifier, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration.cs
@@ -3,6 +3,9 @@ using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Extensions;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Triggers;
@@ -15,6 +18,7 @@ namespace ZCrew.StateCraft.States;
 /// <inheritdoc cref="IParameterlessStateConfiguration{TState,TTransition}"/>
 internal class StateConfiguration<TState, TTransition>
     : IInitialStateConfiguration<TState, TTransition>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -291,6 +295,15 @@ internal class StateConfiguration<TState, TTransition>
     public void AddToValidationContext(StateMachineValidationContext<TState, TTransition> context)
     {
         var state = new StateValidationModel<TState, TTransition>(State, TypeParameters);
+        context.States.Add(state);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var id = $"{State}";
+        var descriptor = ToString();
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
@@ -252,14 +252,14 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var id =
+        var identifier =
             $"{State}"
-            + $"_{typeof(T1).RenderingId}"
-            + $"_{typeof(T2).RenderingId}"
-            + $"_{typeof(T3).RenderingId}"
-            + $"_{typeof(T4).RenderingId}";
+            + $"_{typeof(T1).RenderingIdentifier}"
+            + $"_{typeof(T2).RenderingIdentifier}"
+            + $"_{typeof(T3).RenderingIdentifier}"
+            + $"_{typeof(T4).RenderingIdentifier}";
         var descriptor = ToString();
-        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, identifier, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3,T4}.cs
@@ -3,6 +3,10 @@ using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Extensions;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Extensions;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -14,6 +18,7 @@ namespace ZCrew.StateCraft.States;
 /// <inheritdoc cref="IParameterizedStateConfiguration{TState,TTransition,T1,T2,T3,T4}" />
 internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
     : IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3, T4>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -241,6 +246,20 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3, T4>
     public void AddToValidationContext(StateMachineValidationContext<TState, TTransition> context)
     {
         var state = new StateValidationModel<TState, TTransition>(State, TypeParameters);
+        context.States.Add(state);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var id =
+            $"{State}"
+            + $"_{typeof(T1).RenderingId}"
+            + $"_{typeof(T2).RenderingId}"
+            + $"_{typeof(T3).RenderingId}"
+            + $"_{typeof(T4).RenderingId}";
+        var descriptor = ToString();
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
@@ -3,6 +3,10 @@ using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Extensions;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Extensions;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -14,6 +18,7 @@ namespace ZCrew.StateCraft.States;
 /// <inheritdoc cref="IParameterizedStateConfiguration{TState,TTransition,T1,T2,T3,T4}" />
 internal class StateConfiguration<TState, TTransition, T1, T2, T3>
     : IParameterizedStateConfiguration<TState, TTransition, T1, T2, T3>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -241,6 +246,15 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
     public void AddToValidationContext(StateMachineValidationContext<TState, TTransition> context)
     {
         var state = new StateValidationModel<TState, TTransition>(State, TypeParameters);
+        context.States.Add(state);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var id = $"{State}_{typeof(T1).RenderingId}_{typeof(T2).RenderingId}_{typeof(T3).RenderingId}";
+        var descriptor = ToString();
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2,T3}.cs
@@ -252,9 +252,13 @@ internal class StateConfiguration<TState, TTransition, T1, T2, T3>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var id = $"{State}_{typeof(T1).RenderingId}_{typeof(T2).RenderingId}_{typeof(T3).RenderingId}";
+        var identifier =
+            $"{State}"
+            + $"_{typeof(T1).RenderingIdentifier}"
+            + $"_{typeof(T2).RenderingIdentifier}"
+            + $"_{typeof(T3).RenderingIdentifier}";
         var descriptor = ToString();
-        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, identifier, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
@@ -3,6 +3,10 @@ using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Extensions;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Extensions;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -14,6 +18,7 @@ namespace ZCrew.StateCraft.States;
 /// <inheritdoc cref="IParameterizedStateConfiguration{TState,TTransition,T1,T2}" />
 internal class StateConfiguration<TState, TTransition, T1, T2>
     : IParameterizedStateConfiguration<TState, TTransition, T1, T2>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -241,6 +246,15 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
     public void AddToValidationContext(StateMachineValidationContext<TState, TTransition> context)
     {
         var state = new StateValidationModel<TState, TTransition>(State, TypeParameters);
+        context.States.Add(state);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var id = $"{State}_{typeof(T1).RenderingId}_{typeof(T2).RenderingId}";
+        var descriptor = ToString();
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T1,T2}.cs
@@ -252,9 +252,9 @@ internal class StateConfiguration<TState, TTransition, T1, T2>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var id = $"{State}_{typeof(T1).RenderingId}_{typeof(T2).RenderingId}";
+        var identifier = $"{State}_{typeof(T1).RenderingIdentifier}_{typeof(T2).RenderingIdentifier}";
         var descriptor = ToString();
-        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, identifier, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
@@ -257,9 +257,9 @@ internal class StateConfiguration<TState, TTransition, T>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var id = $"{State}_{typeof(T).RenderingId}";
+        var identifier = $"{State}_{typeof(T).RenderingIdentifier}";
         var descriptor = ToString();
-        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, identifier, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
+++ b/src/ZCrew.StateCraft/States/StateConfiguration{T}.cs
@@ -3,6 +3,10 @@ using ZCrew.Extensions.Tasks;
 using ZCrew.StateCraft.Actions;
 using ZCrew.StateCraft.Async;
 using ZCrew.StateCraft.Extensions;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Extensions;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.Transitions;
 using ZCrew.StateCraft.Validation;
@@ -14,6 +18,7 @@ namespace ZCrew.StateCraft.States;
 /// <inheritdoc cref="IParameterizedStateConfiguration{TState,TTransition,T}" />
 internal class StateConfiguration<TState, TTransition, T>
     : IParameterizedStateConfiguration<TState, TTransition, T>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -246,6 +251,15 @@ internal class StateConfiguration<TState, TTransition, T>
     public void AddToValidationContext(StateMachineValidationContext<TState, TTransition> context)
     {
         var state = new StateValidationModel<TState, TTransition>(State, TypeParameters);
+        context.States.Add(state);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var id = $"{State}_{typeof(T).RenderingId}";
+        var descriptor = ToString();
+        var state = new StateRenderingModel<TState, TTransition>(State, TypeParameters, id, descriptor);
         context.States.Add(state);
     }
 

--- a/src/ZCrew.StateCraft/Transitions/DirectTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/DirectTransitionConfiguration.cs
@@ -1,3 +1,6 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.States.Configuration;
 using ZCrew.StateCraft.Validation;
@@ -9,6 +12,7 @@ namespace ZCrew.StateCraft.Transitions;
 /// <inheritdoc cref="ITransitionConfiguration{TState,TTransition}"/>
 internal class DirectTransitionConfiguration<TState, TTransition>
     : ITransitionConfiguration<TState, TTransition>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -62,6 +66,19 @@ internal class DirectTransitionConfiguration<TState, TTransition>
             this.nextStateConfiguration.TypeParameters,
             this.previousStateConfiguration.IsConditional || this.nextStateConfiguration.IsConditional
         );
+        context.Transitions.Add(transition);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var descriptor = $"{this.transitionValue}";
+        var conditions = new List<string>();
+
+        conditions.AddRange(this.previousStateConfiguration.RenderConditions());
+        conditions.AddRange(this.nextStateConfiguration.RenderConditions());
+
+        var transition = new TransitionRenderingModel<TState, TTransition>(descriptor, conditions);
         context.Transitions.Add(transition);
     }
 

--- a/src/ZCrew.StateCraft/Transitions/FromTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/FromTransitionConfiguration.cs
@@ -1,3 +1,6 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.States;
 using ZCrew.StateCraft.States.Configuration;
@@ -11,6 +14,7 @@ namespace ZCrew.StateCraft.Transitions;
 internal class FromTransitionConfiguration<TState, TTransition>
     : IFromTransitionConfiguration<TState, TTransition>,
         IFromAllStatesTransitionConfiguration<TState, TTransition>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
@@ -96,7 +100,7 @@ internal class FromTransitionConfiguration<TState, TTransition>
                 continue;
             }
 
-            // Use a dynamic previous state. There are no conditions and so we don't care about the type parameters
+            // Use a dynamic previous state. There are no conditions, so we don't care about the type parameters
             var previousState = new DynamicPreviousState<TState, TTransition>(state);
             var transition = new DirectTransition<TState, TTransition>(
                 previousState,
@@ -132,6 +136,28 @@ internal class FromTransitionConfiguration<TState, TTransition>
                 this.nextStateConfiguration.TypeParameters,
                 this.nextStateConfiguration.IsConditional
             );
+            context.Transitions.Add(transition);
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var descriptor = $"{this.transitionValue}";
+        var conditions = this.nextStateConfiguration.RenderConditions().ToArray();
+
+        // This requires all states to be loaded ahead of time. We can just add all states and then all transitions
+        foreach (var state in context.States)
+        {
+            var excluded = this.excludedStates.Any(excludedState =>
+                excludedState.Matches(state.State, state.TypeParameters)
+            );
+            if (excluded)
+            {
+                continue;
+            }
+
+            var transition = new TransitionRenderingModel<TState, TTransition>(descriptor, conditions);
             context.Transitions.Add(transition);
         }
     }

--- a/src/ZCrew.StateCraft/Transitions/MappedTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/MappedTransitionConfiguration.cs
@@ -1,4 +1,7 @@
 using ZCrew.StateCraft.Mapping.Contracts;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.States.Configuration;
 using ZCrew.StateCraft.Validation;
@@ -10,12 +13,14 @@ namespace ZCrew.StateCraft.Transitions;
 /// <inheritdoc cref="ITransitionConfiguration{TState,TTransition}"/>
 internal class MappedTransitionConfiguration<TState, TTransition>
     : ITransitionConfiguration<TState, TTransition>,
+        IRenderable<TState, TTransition>,
         IValidatable<TState, TTransition>
     where TState : notnull
     where TTransition : notnull
 {
     private readonly IPreviousStateConfiguration<TState, TTransition> previousStateConfiguration;
     private readonly INextStateConfiguration<TState, TTransition> nextStateConfiguration;
+    private readonly TTransition transitionValue;
     private readonly IMappingFunction mappingFunction;
 
     /// <summary>
@@ -35,31 +40,9 @@ internal class MappedTransitionConfiguration<TState, TTransition>
     {
         this.previousStateConfiguration = previousStateConfiguration;
         this.nextStateConfiguration = nextStateConfiguration;
-        TransitionValue = transition;
+        this.transitionValue = transition;
         this.mappingFunction = mappingFunction;
     }
-
-    /// <inheritdoc />
-    public TState PreviousStateValue => this.previousStateConfiguration.StateValue;
-
-    /// <inheritdoc />
-    public TTransition TransitionValue { get; }
-
-    /// <inheritdoc />
-    public TState NextStateValue => this.nextStateConfiguration.StateValue;
-
-    /// <inheritdoc />
-    public IReadOnlyList<Type> PreviousStateTypeParameters => this.previousStateConfiguration.TypeParameters;
-
-    /// <inheritdoc/>
-    public IReadOnlyList<Type> TransitionTypeParameters { get; } = [];
-
-    /// <inheritdoc />
-    public IReadOnlyList<Type> NextStateTypeParameters => this.nextStateConfiguration.TypeParameters;
-
-    /// <inheritdoc />
-    public bool IsConditional =>
-        this.previousStateConfiguration.IsConditional || this.nextStateConfiguration.IsConditional;
 
     /// <inheritdoc />
     public void Build(IStateMachine<TState, TTransition> stateMachine)
@@ -69,7 +52,7 @@ internal class MappedTransitionConfiguration<TState, TTransition>
         var transition = new MappedTransition<TState, TTransition>(
             previousState,
             nextState,
-            TransitionValue,
+            this.transitionValue,
             this.mappingFunction,
             stateMachine
         );
@@ -81,14 +64,27 @@ internal class MappedTransitionConfiguration<TState, TTransition>
     public void AddToValidationContext(StateMachineValidationContext<TState, TTransition> context)
     {
         var transition = new TransitionValidationModel<TState, TTransition>(
-            PreviousStateValue,
-            TransitionValue,
-            NextStateValue,
-            PreviousStateTypeParameters,
-            TransitionTypeParameters,
-            NextStateTypeParameters,
-            IsConditional
+            this.previousStateConfiguration.StateValue,
+            this.transitionValue,
+            this.nextStateConfiguration.StateValue,
+            this.previousStateConfiguration.TypeParameters,
+            [],
+            this.nextStateConfiguration.TypeParameters,
+            this.previousStateConfiguration.IsConditional || this.nextStateConfiguration.IsConditional
         );
+        context.Transitions.Add(transition);
+    }
+
+    /// <inheritdoc />
+    public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
+    {
+        var descriptor = $"{this.transitionValue}";
+        var conditions = new List<string>();
+
+        conditions.AddRange(this.previousStateConfiguration.RenderConditions());
+        conditions.AddRange(this.nextStateConfiguration.RenderConditions());
+
+        var transition = new TransitionRenderingModel<TState, TTransition>(descriptor, conditions);
         context.Transitions.Add(transition);
     }
 
@@ -96,13 +92,13 @@ internal class MappedTransitionConfiguration<TState, TTransition>
     public override string ToString()
     {
         if (
-            PreviousStateValue.Equals(NextStateValue)
-            && PreviousStateTypeParameters.SequenceEqual(NextStateTypeParameters)
+            this.previousStateConfiguration.StateValue.Equals(this.nextStateConfiguration.StateValue)
+            && this.previousStateConfiguration.TypeParameters.SequenceEqual(this.nextStateConfiguration.TypeParameters)
         )
         {
-            return $"{TransitionValue}({this.previousStateConfiguration}) ↩";
+            return $"{this.transitionValue}({this.previousStateConfiguration}) ↩";
         }
 
-        return $"{TransitionValue}({this.previousStateConfiguration}) → {this.nextStateConfiguration}";
+        return $"{this.transitionValue}({this.previousStateConfiguration}) → {this.nextStateConfiguration}";
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/DirectTransitionConfigurationTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/DirectTransitionConfigurationTests.cs
@@ -1,0 +1,118 @@
+using NSubstitute;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States.Configuration;
+using ZCrew.StateCraft.Transitions;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class DirectTransitionConfigurationTests
+{
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldAppendSingleTransition()
+    {
+        // Arrange
+        var previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new DirectTransitionConfiguration<string, string>(previous, next, "T");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Single(context.Transitions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldUseTransitionValueAsDescriptor()
+    {
+        // Arrange
+        var previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new DirectTransitionConfiguration<string, string>(previous, next, "T");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal("T", transition.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenNeitherSideIsConditional_ShouldHaveNoConditions()
+    {
+        // Arrange
+        var previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        previous.RenderConditions().Returns([]);
+        next.RenderConditions().Returns([]);
+        var configuration = new DirectTransitionConfiguration<string, string>(previous, next, "T");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Empty(transition.Conditions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenOnlyPreviousIsConditional_ShouldIncludePreviousConditions()
+    {
+        // Arrange
+        var previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        previous.RenderConditions().Returns(["prev"]);
+        next.RenderConditions().Returns([]);
+        var configuration = new DirectTransitionConfiguration<string, string>(previous, next, "T");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal(["prev"], transition.Conditions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenOnlyNextIsConditional_ShouldIncludeNextConditions()
+    {
+        // Arrange
+        var previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        previous.RenderConditions().Returns([]);
+        next.RenderConditions().Returns(["next"]);
+        var configuration = new DirectTransitionConfiguration<string, string>(previous, next, "T");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal(["next"], transition.Conditions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenBothSidesAreConditional_ShouldIncludePreviousThenNextConditionsInOrder()
+    {
+        // Arrange
+        var previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        previous.RenderConditions().Returns(["prev1", "prev2"]);
+        next.RenderConditions().Returns(["next1", "next2"]);
+        var configuration = new DirectTransitionConfiguration<string, string>(previous, next, "T");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal(["prev1", "prev2", "next1", "next2"], transition.Conditions);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/FromTransitionConfigurationTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/FromTransitionConfigurationTests.cs
@@ -1,0 +1,118 @@
+using NSubstitute;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.Rendering.Models;
+using ZCrew.StateCraft.States.Configuration;
+using ZCrew.StateCraft.Transitions;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class FromTransitionConfigurationTests
+{
+    [Fact]
+    public void AddToRenderingContext_WhenContextHasNoStates_ShouldAddNoTransitions()
+    {
+        // Arrange
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new FromTransitionConfiguration<string, string>("T", next);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Empty(context.Transitions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenContextHasMultipleStates_ShouldAddOneTransitionPerState()
+    {
+        // Arrange
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new FromTransitionConfiguration<string, string>("T", next);
+        var context = new StateMachineRenderingContext<string, string>();
+        context.States.Add(new StateRenderingModel<string, string>("A", [], "A", "A"));
+        context.States.Add(new StateRenderingModel<string, string>("B", [], "B", "B"));
+        context.States.Add(new StateRenderingModel<string, string>("C", [], "C", "C"));
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Equal(3, context.Transitions.Count);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldUseTransitionValueForEveryDescriptor()
+    {
+        // Arrange
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new FromTransitionConfiguration<string, string>("T", next);
+        var context = new StateMachineRenderingContext<string, string>();
+        context.States.Add(new StateRenderingModel<string, string>("A", [], "A", "A"));
+        context.States.Add(new StateRenderingModel<string, string>("B", [], "B", "B"));
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.All(context.Transitions, transition => Assert.Equal("T", transition.Descriptor));
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenNextIsConditional_ShouldUseNextConditionsForEveryTransition()
+    {
+        // Arrange
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        next.RenderConditions().Returns(["c1", "c2"]);
+        var configuration = new FromTransitionConfiguration<string, string>("T", next);
+        var context = new StateMachineRenderingContext<string, string>();
+        context.States.Add(new StateRenderingModel<string, string>("A", [], "A", "A"));
+        context.States.Add(new StateRenderingModel<string, string>("B", [], "B", "B"));
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.All(context.Transitions, transition => Assert.Equal(["c1", "c2"], transition.Conditions));
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenStateMatchesParameterlessExclusion_ShouldSkipThatState()
+    {
+        // Arrange
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new FromTransitionConfiguration<string, string>("T", next);
+        configuration.AllStates().Except("B");
+        var context = new StateMachineRenderingContext<string, string>();
+        context.States.Add(new StateRenderingModel<string, string>("A", [], "A", "A"));
+        context.States.Add(new StateRenderingModel<string, string>("B", [], "B", "B"));
+        context.States.Add(new StateRenderingModel<string, string>("C", [], "C", "C"));
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Equal(2, context.Transitions.Count);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenStateMatchesTypedExclusion_ShouldSkipOnlyMatchingArityAndType()
+    {
+        // Arrange
+        var next = Substitute.For<INextStateConfiguration<string, string>>();
+        var configuration = new FromTransitionConfiguration<string, string>("T", next);
+        configuration.AllStates().Except<int>("A");
+        var context = new StateMachineRenderingContext<string, string>();
+        context.States.Add(new StateRenderingModel<string, string>("A", [], "A", "A"));
+        context.States.Add(new StateRenderingModel<string, string>("A", [typeof(int)], "A_System.Int32", "A<int>"));
+        context.States.Add(
+            new StateRenderingModel<string, string>("A", [typeof(string)], "A_System.String", "A<string>")
+        );
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Equal(2, context.Transitions.Count);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/MappedTransitionConfigurationTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/MappedTransitionConfigurationTests.cs
@@ -1,0 +1,119 @@
+using NSubstitute;
+using ZCrew.StateCraft.Mapping.Contracts;
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States.Configuration;
+using ZCrew.StateCraft.Transitions;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class MappedTransitionConfigurationTests
+{
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldAppendSingleTransition()
+    {
+        // Arrange
+        var configuration = CreateConfiguration("T", out _, out _);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Single(context.Transitions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldUseTransitionValueAsDescriptor()
+    {
+        // Arrange
+        var configuration = CreateConfiguration("T", out _, out _);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal("T", transition.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenNeitherSideIsConditional_ShouldHaveNoConditions()
+    {
+        // Arrange
+        var configuration = CreateConfiguration("T", out var previous, out var next);
+        previous.RenderConditions().Returns([]);
+        next.RenderConditions().Returns([]);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Empty(transition.Conditions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenOnlyPreviousIsConditional_ShouldIncludePreviousConditions()
+    {
+        // Arrange
+        var configuration = CreateConfiguration("T", out var previous, out var next);
+        previous.RenderConditions().Returns(["prev"]);
+        next.RenderConditions().Returns([]);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal(["prev"], transition.Conditions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenOnlyNextIsConditional_ShouldIncludeNextConditions()
+    {
+        // Arrange
+        var configuration = CreateConfiguration("T", out var previous, out var next);
+        previous.RenderConditions().Returns([]);
+        next.RenderConditions().Returns(["next"]);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal(["next"], transition.Conditions);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenBothSidesAreConditional_ShouldIncludePreviousThenNextConditionsInOrder()
+    {
+        // Arrange
+        var configuration = CreateConfiguration("T", out var previous, out var next);
+        previous.RenderConditions().Returns(["prev1", "prev2"]);
+        next.RenderConditions().Returns(["next1", "next2"]);
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var transition = Assert.Single(context.Transitions);
+        Assert.Equal(["prev1", "prev2", "next1", "next2"], transition.Conditions);
+    }
+
+    private static MappedTransitionConfiguration<string, string> CreateConfiguration(
+        string transition,
+        out IPreviousStateConfiguration<string, string> previous,
+        out INextStateConfiguration<string, string> next
+    )
+    {
+        previous = Substitute.For<IPreviousStateConfiguration<string, string>>();
+        next = Substitute.For<INextStateConfiguration<string, string>>();
+        var mapping = Substitute.For<IMappingFunction>();
+        return new MappedTransitionConfiguration<string, string>(previous, next, transition, mapping);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfigurationTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfigurationTests.cs
@@ -1,0 +1,87 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class StateConfigurationTests
+{
+    [Fact]
+    public void AddToRenderingContext_WhenContextIsEmpty_ShouldAppendSingleStateModel()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S", state.State);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldUseStateValueAsName()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S", state.Name);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldUseToStringAsDescriptor()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal(configuration.ToString(), state.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldExposeEmptyTypeParameters()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Empty(state.TypeParameters);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenContextHasExistingStates_ShouldAppendWithoutReplacing()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string>("B");
+        var existing = new StateConfiguration<string, string>("A");
+        var context = new StateMachineRenderingContext<string, string>();
+        existing.AddToRenderingContext(context);
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Collection(
+            context.States,
+            first => Assert.Equal("A", first.State),
+            second => Assert.Equal("B", second.State)
+        );
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfigurationTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfigurationTests.cs
@@ -32,7 +32,7 @@ public class StateConfigurationTests
 
         // Assert
         var state = Assert.Single(context.States);
-        Assert.Equal("S", state.Name);
+        Assert.Equal("S", state.Identifier);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3,T4}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3,T4}Tests.cs
@@ -32,7 +32,7 @@ public class StateConfigurationT1T2T3T4Tests
 
         // Assert
         var state = Assert.Single(context.States);
-        Assert.Equal("S_System.Int32_System.String_System.Boolean_System.Double", state.Name);
+        Assert.Equal("S_System.Int32_System.String_System.Boolean_System.Double", state.Identifier);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3,T4}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3,T4}Tests.cs
@@ -1,0 +1,67 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class StateConfigurationT1T2T3T4Tests
+{
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_T4_WhenContextIsEmpty_ShouldAppendSingleStateModel()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool, double>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S", state.State);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_T4_WhenInvoked_ShouldComposeNameFromStateValueAndTypeRenderingIds()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool, double>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S_System.Int32_System.String_System.Boolean_System.Double", state.Name);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_T4_WhenInvoked_ShouldUseToStringAsDescriptor()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool, double>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal(configuration.ToString(), state.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_T4_WhenInvoked_ShouldExposeTypeArgumentsInDeclarationOrder()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool, double>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal([typeof(int), typeof(string), typeof(bool), typeof(double)], state.TypeParameters);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3}Tests.cs
@@ -1,0 +1,67 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class StateConfigurationT1T2T3Tests
+{
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_WhenContextIsEmpty_ShouldAppendSingleStateModel()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S", state.State);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_WhenInvoked_ShouldComposeNameFromStateValueAndTypeRenderingIds()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S_System.Int32_System.String_System.Boolean", state.Name);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_WhenInvoked_ShouldUseToStringAsDescriptor()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal(configuration.ToString(), state.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_T3_WhenInvoked_ShouldExposeTypeArgumentsInDeclarationOrder()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string, bool>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal([typeof(int), typeof(string), typeof(bool)], state.TypeParameters);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2,T3}Tests.cs
@@ -32,7 +32,7 @@ public class StateConfigurationT1T2T3Tests
 
         // Assert
         var state = Assert.Single(context.States);
-        Assert.Equal("S_System.Int32_System.String_System.Boolean", state.Name);
+        Assert.Equal("S_System.Int32_System.String_System.Boolean", state.Identifier);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2}Tests.cs
@@ -1,0 +1,67 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class StateConfigurationT1T2Tests
+{
+    [Fact]
+    public void AddToRenderingContext_T1_T2_WhenContextIsEmpty_ShouldAppendSingleStateModel()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S", state.State);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_WhenInvoked_ShouldComposeNameFromStateValueAndTypeRenderingIds()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S_System.Int32_System.String", state.Name);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_WhenInvoked_ShouldUseToStringAsDescriptor()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal(configuration.ToString(), state.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T1_T2_WhenInvoked_ShouldExposeTypeArgumentsInDeclarationOrder()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal([typeof(int), typeof(string)], state.TypeParameters);
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T1,T2}Tests.cs
@@ -32,7 +32,7 @@ public class StateConfigurationT1T2Tests
 
         // Assert
         var state = Assert.Single(context.States);
-        Assert.Equal("S_System.Int32_System.String", state.Name);
+        Assert.Equal("S_System.Int32_System.String", state.Identifier);
     }
 
     [Fact]

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T}Tests.cs
@@ -1,0 +1,87 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.States;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class StateConfigurationTTests
+{
+    [Fact]
+    public void AddToRenderingContext_T_WhenContextIsEmpty_ShouldAppendSingleStateModel()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S", state.State);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T_WhenInvoked_ShouldComposeNameFromStateValueAndTypeRenderingId()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal("S_System.Int32", state.Name);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T_WhenInvoked_ShouldUseToStringAsDescriptor()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal(configuration.ToString(), state.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T_WhenInvoked_ShouldExposeTypeArgumentInTypeParameters()
+    {
+        // Arrange
+        var configuration = new StateConfiguration<string, string, int>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        var state = Assert.Single(context.States);
+        Assert.Equal([typeof(int)], state.TypeParameters);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_T_WhenTwoStatesShareValueButDifferTypeArgument_ShouldProduceDistinctNames()
+    {
+        // Arrange
+        var intConfiguration = new StateConfiguration<string, string, int>("S");
+        var stringConfiguration = new StateConfiguration<string, string, string>("S");
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        intConfiguration.AddToRenderingContext(context);
+        stringConfiguration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Collection(
+            context.States,
+            first => Assert.Equal("S_System.Int32", first.Name),
+            second => Assert.Equal("S_System.String", second.Name)
+        );
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T}Tests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateConfiguration{T}Tests.cs
@@ -32,7 +32,7 @@ public class StateConfigurationTTests
 
         // Assert
         var state = Assert.Single(context.States);
-        Assert.Equal("S_System.Int32", state.Name);
+        Assert.Equal("S_System.Int32", state.Identifier);
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class StateConfigurationTTests
         // Assert
         Assert.Collection(
             context.States,
-            first => Assert.Equal("S_System.Int32", first.Name),
-            second => Assert.Equal("S_System.String", second.Name)
+            first => Assert.Equal("S_System.Int32", first.Identifier),
+            second => Assert.Equal("S_System.String", second.Identifier)
         );
     }
 }

--- a/tests/ZCrew.StateCraft.UnitTests/Rendering/StateMachineConfigurationTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Rendering/StateMachineConfigurationTests.cs
@@ -1,0 +1,37 @@
+using ZCrew.StateCraft.Rendering;
+using ZCrew.StateCraft.StateMachines;
+
+namespace ZCrew.StateCraft.UnitTests.Rendering;
+
+public class StateMachineConfigurationTests
+{
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldSetStateMachineWithFixedDescriptor()
+    {
+        // Arrange
+        var configuration = new StateMachineConfiguration<string, string>();
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.NotNull(context.StateMachine);
+        Assert.Equal("State Machine", context.StateMachine.Descriptor);
+    }
+
+    [Fact]
+    public void AddToRenderingContext_WhenInvoked_ShouldNotPopulateStatesOrTransitions()
+    {
+        // Arrange
+        var configuration = new StateMachineConfiguration<string, string>();
+        var context = new StateMachineRenderingContext<string, string>();
+
+        // Act
+        configuration.AddToRenderingContext(context);
+
+        // Assert
+        Assert.Empty(context.States);
+        Assert.Empty(context.Transitions);
+    }
+}


### PR DESCRIPTION
Adds rendering to:

1. State machine
2. States
3. Transitions

This rendering grabs the descriptors (if available) and then bundles the descriptors with other metadata that could be used to output a state machine diagram. Currently this is not connected anywhere; but, unit tests were added to show the rendering works as intended.

Closes #159 