### PR TITLE
#161 - Add basic mermaid diagram implementation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,6 @@
     <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.0" />
-    <PackageVersion Include="ZCrew.Extensions.Tasks" Version="1.0.0-preview.2" />
+    <PackageVersion Include="ZCrew.Extensions.Tasks" Version="1.0.1" />
   </ItemGroup>
 </Project>

--- a/ZCrew.StateCraft.slnx
+++ b/ZCrew.StateCraft.slnx
@@ -3,6 +3,7 @@
     <File Path="docs/1-introduction.md" />
     <File Path="docs/12-exception-behavior.md" />
     <File Path="docs/13-inverted-transitions.md" />
+    <File Path="docs/14-mermaid-diagrams.md" />
     <File Path="docs/2-getting-started.md" />
     <File Path="docs/3-general-concepts.md" />
     <File Path="docs/4-state-machine-lifecycle.md" />
@@ -24,10 +25,12 @@
     <File Path="samples/OrderProcessorSample/README.md" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/ZCrew.StateCraft.Mermaid/ZCrew.StateCraft.Mermaid.csproj" />
     <Project Path="src/ZCrew.StateCraft/ZCrew.StateCraft.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZCrew.StateCraft.IntegrationTests/ZCrew.StateCraft.IntegrationTests.csproj" />
+    <Project Path="tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ZCrew.StateCraft.Mermaid.IntegrationTests.csproj" />
     <Project Path="tests/ZCrew.StateCraft.UnitTests/ZCrew.StateCraft.UnitTests.csproj" />
   </Folder>
 </Solution>

--- a/docs/1-introduction.md
+++ b/docs/1-introduction.md
@@ -79,3 +79,4 @@ await machine.Deactivate(cancellationToken);
 - [Exception Handling](./11-exception-handling.md) - Error handling strategies
 - [Exception Behavior](./12-exception-behavior.md) - Custom exception handling implementations
 - [Inverted Transitions](./13-inverted-transitions.md) - Define transitions by destination instead of source
+- [Mermaid Diagrams](./14-mermaid-diagrams.md) - Render a configuration as a Mermaid `stateDiagram-v2`

--- a/docs/14-mermaid-diagrams.md
+++ b/docs/14-mermaid-diagrams.md
@@ -1,0 +1,188 @@
+# Mermaid Diagrams
+
+The `ZCrew.StateCraft.Mermaid` package renders a state machine configuration as a
+[Mermaid `stateDiagram-v2`](https://mermaid.js.org/syntax/stateDiagram.html) diagram. It is useful for documenting the
+shape of a state machine without keeping a hand-written diagram in sync with the code.
+
+## Installation
+
+Add a reference to the `ZCrew.StateCraft.Mermaid` package alongside the core package:
+
+```xml
+<PackageReference Include="ZCrew.StateCraft" />
+<PackageReference Include="ZCrew.StateCraft.Mermaid" />
+```
+
+Then add the namespace:
+
+```csharp
+using ZCrew.StateCraft.Mermaid;
+```
+
+## Rendering a Diagram
+
+`ToMermaidDiagram()` is an extension on `IStateMachineConfiguration<TState, TTransition>`, so the diagram is produced
+directly from the configuration — there is no need to `Build()` the state machine first:
+
+```csharp
+enum State { Idle, Running, Finished }
+enum Transition { Start, Complete }
+
+static bool QueueIsHealthy() => true;
+
+var configuration = StateMachine
+    .Configure<State, Transition>()
+    .WithInitialState(State.Idle)
+    .WithState(State.Idle, state => state
+        .WithTransition(Transition.Start, t => t
+            .If(QueueIsHealthy)
+            .To(State.Running)))
+    .WithState(State.Running, state => state
+        .WithTransition(Transition.Complete, State.Finished))
+    .WithState(State.Finished, state => state);
+
+var diagram = configuration.ToMermaidDiagram();
+```
+
+`diagram` is a `string` containing the diagram text. Write it to a file, embed it in a Markdown document, or paste it
+into the [Mermaid live editor](https://mermaid.live).
+
+### Sample Output
+
+The configuration above renders as:
+
+````text
+---
+title: State Machine
+---
+stateDiagram-v2
+    direction TB
+
+    Idle: Idle
+    Running: Running
+    Finished: Finished
+
+    Idle --> Running : Start <br/> If: QueueIsHealthy
+    Running --> Finished : Complete
+````
+
+When passed through a Mermaid renderer it produces:
+
+```mermaid
+---
+title: State Machine
+---
+stateDiagram-v2
+    direction TB
+
+    Idle: Idle
+    Running: Running
+    Finished: Finished
+
+    Idle --> Running : Start <br/> If: QueueIsHealthy
+    Running --> Finished : Complete
+```
+
+## Options
+
+`ToMermaidDiagram` has three overloads. Pick whichever fits the call site:
+
+```csharp
+// Defaults
+configuration.ToMermaidDiagram();
+
+// Explicit options instance
+configuration.ToMermaidDiagram(new MermaidOptions
+{
+    Direction = MermaidDirection.LeftToRight,
+    Newline = MermaidNewline.HtmlSingleLineBreak,
+});
+
+// Configure callback against a fresh options instance
+configuration.ToMermaidDiagram(options =>
+{
+    options.Direction = MermaidDirection.LeftToRight;
+    options.Newline = MermaidNewline.HtmlSingleLineBreak;
+});
+```
+
+### `Direction`
+
+Sets the layout direction emitted at the top of the diagram (`direction TB` or `direction LR`).
+
+| Value          | Mermaid token | Description                            |
+|----------------|---------------|----------------------------------------|
+| `TopToBottom`  | `TB`          | States flow top to bottom (default).   |
+| `LeftToRight`  | `LR`          | States flow left to right.             |
+
+### `Newline`
+
+Controls how newline characters inside a descriptor (state name, transition descriptor, or condition descriptor) are
+rendered. Mermaid does not allow raw newlines inside a descriptor, so they must be transformed:
+
+| Value                 | Behavior                                                                       |
+|-----------------------|--------------------------------------------------------------------------------|
+| `Ignore`              | Strip newlines entirely; surrounding text is concatenated (default).           |
+| `Space`               | Replace each newline with a single space.                                      |
+| `HtmlSingleLineBreak` | Replace each newline with `<br/>` so descriptors render as multiple lines.     |
+
+`HtmlSingleLineBreak` is the right choice when descriptors carry multi-line text you want to preserve visually — for
+example, larger block-bodied lambda conditions (see the next section).
+
+### Other Encoding Behavior
+
+Regardless of options, descriptors are always escaped to keep Mermaid's parser happy:
+
+- `<` becomes `#lt;`, `>` becomes `#gt;` — so a parameterized state's `<int>` suffix renders as `&ltint&gt`.
+- Runs of consecutive spaces have the second-and-later characters replaced with `#nbsp;` so Mermaid does not collapse
+  them.
+
+## Tips
+
+### Use the Descriptor Overload for Complex Conditions
+
+Every `If(...)` overload accepts an optional descriptor parameter that defaults to
+`[CallerArgumentExpression(nameof(condition))]`. For a method-group reference like `If(QueueIsHealthy)` the captured
+expression is just `QueueIsHealthy`, which reads cleanly. But when the condition is a larger inline expression or a
+block-bodied lambda, the captured text becomes noisy:
+
+```csharp
+// Captured descriptor: "() => { var isAuthorized = this.userService.IsAuthorized(UserId); ..."
+.If(() =>
+{
+    var isAuthorized = this.userService.IsAuthorized(UserId);
+    var hasCapacity = Quantity == 0 || this.allocationService.TryAllocate(Quantity, InventoryId);
+    return isAuthorized && hasCapacity;
+})
+```
+
+Pass an explicit descriptor to keep the diagram readable:
+
+```csharp
+.If(() => /* same condition as before ... */, "ready to process")
+```
+
+The condition then renders as `If: ready to process` instead of the verbatim expression text.
+
+### Prefer Methods or Properties for Conditions When Possible
+
+A method group or property reference makes the diagram self-documenting without needing an explicit descriptor:
+
+```csharp
+// Renders property check as: If: QueueIsHealthy
+.If(QueueIsHealthy)
+
+// Renders method group as: If: policy.CanCancel
+.If(policy.CanCancel)
+
+// Renders lambda method as: If: () => policy.CanCancel
+.If(() => policy.CanCancel)
+```
+
+## Next Steps
+
+- [Parameterless Transitions](./6-parameterless-transitions.md) - Simple state-to-state transitions
+- [Parameterized Transitions](./7-parameterized-transitions.md) - Transitions that carry typed data
+- [Mapped Transitions](./8-mapped-transitions.md) - Automatic parameter conversion
+- [Reentrant Transitions](./9-reentrant-transitions.md) - Same-parameter transitions
+- [Inverted Transitions](./13-inverted-transitions.md) - Define transitions by destination instead of source

--- a/src/ZCrew.StateCraft.Mermaid/MermaidDirection.cs
+++ b/src/ZCrew.StateCraft.Mermaid/MermaidDirection.cs
@@ -1,0 +1,17 @@
+namespace ZCrew.StateCraft.Mermaid;
+
+/// <summary>
+///     The layout direction Mermaid uses when rendering the state diagram.
+/// </summary>
+public enum MermaidDirection
+{
+    /// <summary>
+    ///     States flow from the top of the diagram to the bottom.
+    /// </summary>
+    TopToBottom,
+
+    /// <summary>
+    ///     States flow from the left of the diagram to the right.
+    /// </summary>
+    LeftToRight,
+}

--- a/src/ZCrew.StateCraft.Mermaid/MermaidNewline.cs
+++ b/src/ZCrew.StateCraft.Mermaid/MermaidNewline.cs
@@ -1,0 +1,23 @@
+namespace ZCrew.StateCraft.Mermaid;
+
+/// <summary>
+///     How newline characters inside encoded descriptors are handled when rendered into a Mermaid diagram.
+/// </summary>
+public enum MermaidNewline
+{
+    /// <summary>
+    ///     Strip newline characters entirely; subsequent text is concatenated against the preceding line.
+    /// </summary>
+    Ignore,
+
+    /// <summary>
+    ///     Replace each newline with a single space so descriptors stay on one Mermaid line.
+    /// </summary>
+    Space,
+
+    /// <summary>
+    ///     Replace each newline with the HTML <c>&lt;br/&gt;</c> tag so descriptors render as multiple lines in
+    ///     the diagram.
+    /// </summary>
+    HtmlSingleLineBreak,
+}

--- a/src/ZCrew.StateCraft.Mermaid/MermaidOptions.cs
+++ b/src/ZCrew.StateCraft.Mermaid/MermaidOptions.cs
@@ -1,0 +1,18 @@
+namespace ZCrew.StateCraft.Mermaid;
+
+/// <summary>
+///     Configuration options that control how a state machine is rendered as a Mermaid diagram.
+/// </summary>
+public class MermaidOptions
+{
+    /// <summary>
+    ///     The layout direction the diagram should use. Defaults to <see cref="MermaidDirection.TopToBottom"/>.
+    /// </summary>
+    public MermaidDirection Direction { get; set; } = MermaidDirection.TopToBottom;
+
+    /// <summary>
+    ///     The strategy used when newline characters are encountered inside an encoded descriptor. Defaults to
+    ///     <see cref="MermaidNewline.Ignore"/>.
+    /// </summary>
+    public MermaidNewline Newline { get; set; } = MermaidNewline.Ignore;
+}

--- a/src/ZCrew.StateCraft.Mermaid/README.md
+++ b/src/ZCrew.StateCraft.Mermaid/README.md
@@ -1,0 +1,1 @@
+# ZCrew.StateCraft.Mermaid

--- a/src/ZCrew.StateCraft.Mermaid/README.md
+++ b/src/ZCrew.StateCraft.Mermaid/README.md
@@ -1,1 +1,114 @@
 # ZCrew.StateCraft.Mermaid
+
+A Mermaid diagram renderer for [ZCrew.StateCraft](https://www.nuget.org/packages/ZCrew.StateCraft). Render any state machine configuration as a [Mermaid `stateDiagram-v2`](https://mermaid.js.org/syntax/stateDiagram.html) diagram so documentation stays in sync with the code rather than being hand-maintained alongside it.
+
+## Features
+
+- **One-line rendering** - `ToMermaidDiagram()` produces the diagram from a configuration; no need to `Build()` first
+- **[Layout direction](docs/14-mermaid-diagrams.md#direction)** - Top-to-bottom or left-to-right layouts
+- **[Newline handling](docs/14-mermaid-diagrams.md#newline)** - Strip newlines, replace them with spaces, or render them as `<br/>` line breaks inside descriptors
+- **Condition descriptors** - Guarded transitions render with `If` / `And` clauses pulled from each condition's descriptor
+- **Parameterized state support** - Type parameters appear in both the state identifier and its descriptor
+- **Mermaid-safe escaping** - Angle brackets and consecutive spaces are encoded so the diagram parses cleanly
+
+## Installation
+
+This package is available on NuGet as `ZCrew.StateCraft.Mermaid` for these frameworks:
+
+- .NET 8.0
+- .NET 9.0
+- .NET 10.0
+
+```xml
+<PackageReference Include="ZCrew.StateCraft" Version="1.0.0" />
+<PackageReference Include="ZCrew.StateCraft.Mermaid" Version="1.0.0" />
+```
+
+## Quick Start
+
+`ToMermaidDiagram()` is an extension on `IStateMachineConfiguration<TState, TTransition>`:
+
+```csharp
+using ZCrew.StateCraft;
+using ZCrew.StateCraft.Mermaid;
+
+enum State { Idle, Running, Finished }
+enum Trigger { Start, Complete }
+
+static bool QueueIsHealthy() => true;
+
+var configuration = StateMachine
+    .Configure<State, Trigger>()
+    .WithInitialState(State.Idle)
+    .WithState(State.Idle, state => state
+        .WithTransition(Trigger.Start, t => t
+            .If(QueueIsHealthy)
+            .To(State.Running)))
+    .WithState(State.Running, state => state
+        .WithTransition(Trigger.Complete, State.Finished))
+    .WithState(State.Finished, state => state);
+
+var diagram = configuration.ToMermaidDiagram();
+```
+
+`diagram` is a `string` containing the diagram text — write it to a file, embed it in a Markdown document, or paste it into the [Mermaid live editor](https://mermaid.live).
+
+### Sample Output
+
+The configuration above renders as:
+
+```mermaid
+---
+title: State Machine
+---
+stateDiagram-v2
+    direction TB
+
+    Idle: Idle
+    Running: Running
+    Finished: Finished
+
+    Idle --> Running : Start <br/> If: QueueIsHealthy
+    Running --> Finished : Complete
+```
+
+### Options
+
+`ToMermaidDiagram` has three overloads — defaults, an explicit `MermaidOptions` instance, or a configure callback:
+
+```csharp
+// Defaults
+configuration.ToMermaidDiagram();
+
+// Explicit options instance
+configuration.ToMermaidDiagram(new MermaidOptions
+{
+    Direction = MermaidDirection.LeftToRight,
+    Newline = MermaidNewline.HtmlSingleLineBreak,
+});
+
+// Configure callback against a fresh options instance
+configuration.ToMermaidDiagram(options =>
+{
+    options.Direction = MermaidDirection.LeftToRight;
+    options.Newline = MermaidNewline.HtmlSingleLineBreak;
+});
+```
+
+### Readable Conditions
+
+Every `If(...)` overload accepts an optional descriptor that defaults to `[CallerArgumentExpression]`. Method groups and properties produce clean descriptors out of the box; for complex inline lambdas, pass an explicit descriptor so the diagram stays readable:
+
+```csharp
+.If(() => /* large block-bodied condition... */, "ready to process")
+```
+
+The condition then renders as `If: ready to process` instead of the verbatim expression text.
+
+## Documentation
+
+For detailed documentation, see [Mermaid Diagrams](docs/14-mermaid-diagrams.md) in the docs folder.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/src/ZCrew.StateCraft.Mermaid/StateMachineConfigurationExtensions.cs
+++ b/src/ZCrew.StateCraft.Mermaid/StateMachineConfigurationExtensions.cs
@@ -1,0 +1,139 @@
+using ZCrew.StateCraft.Rendering;
+
+namespace ZCrew.StateCraft.Mermaid;
+
+/// <summary>
+///     Provides extensions on <see cref="IStateMachineConfiguration{TState, TTransition}"/> for producing a Mermaid
+///     <c>stateDiagram-v2</c> representation of a state machine.
+/// </summary>
+public static class StateMachineConfigurationExtensions
+{
+    /// <summary>
+    ///     Renders <paramref name="configuration"/> as a Mermaid <c>stateDiagram-v2</c> diagram string.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <typeparam name="TTransition">The type of the transition.</typeparam>
+    /// <param name="configuration">The state machine configuration to render.</param>
+    /// <returns>The rendered Mermaid diagram.</returns>
+    public static string ToMermaidDiagram<TState, TTransition>(
+        this IStateMachineConfiguration<TState, TTransition> configuration
+    )
+        where TState : notnull
+        where TTransition : notnull
+    {
+        using var stringWriter = new StringWriter();
+
+        configuration.ToMermaidDiagram(stringWriter, new MermaidOptions());
+        return stringWriter.ToString();
+    }
+
+    /// <summary>
+    ///     Renders <paramref name="configuration"/> as a Mermaid <c>stateDiagram-v2</c> diagram string.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <typeparam name="TTransition">The type of the transition.</typeparam>
+    /// <param name="configuration">The state machine configuration to render.</param>
+    /// <param name="options">The Mermaid rendering options to apply.</param>
+    /// <returns>The rendered Mermaid diagram.</returns>
+    public static string ToMermaidDiagram<TState, TTransition>(
+        this IStateMachineConfiguration<TState, TTransition> configuration,
+        MermaidOptions? options
+    )
+        where TState : notnull
+        where TTransition : notnull
+    {
+        using var stringWriter = new StringWriter();
+        options ??= new MermaidOptions();
+
+        configuration.ToMermaidDiagram(stringWriter, options);
+        return stringWriter.ToString();
+    }
+
+    /// <summary>
+    ///     Renders <paramref name="configuration"/> as a Mermaid <c>stateDiagram-v2</c> diagram string, building the
+    ///     options inline via <paramref name="configureOptions"/>.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <typeparam name="TTransition">The type of the transition.</typeparam>
+    /// <param name="configuration">The state machine configuration to render.</param>
+    /// <param name="configureOptions">
+    ///     A callback that mutates a fresh <see cref="MermaidOptions"/> instance, or <see langword="null"/> to use
+    ///     defaults.
+    /// </param>
+    /// <returns>The rendered Mermaid diagram.</returns>
+    public static string ToMermaidDiagram<TState, TTransition>(
+        this IStateMachineConfiguration<TState, TTransition> configuration,
+        Action<MermaidOptions>? configureOptions
+    )
+        where TState : notnull
+        where TTransition : notnull
+    {
+        using var stringWriter = new StringWriter();
+        var options = new MermaidOptions();
+        configureOptions?.Invoke(options);
+
+        configuration.ToMermaidDiagram(stringWriter, options);
+        return stringWriter.ToString();
+    }
+
+    private static void ToMermaidDiagram<TState, TTransition>(
+        this IStateMachineConfiguration<TState, TTransition> configuration,
+        TextWriter writer,
+        MermaidOptions options
+    )
+        where TState : notnull
+        where TTransition : notnull
+    {
+        var rendering = StateMachineRenderingContext.Render(configuration);
+        var title = rendering.StateMachine?.Descriptor.EncodeForMermaid(options) ?? string.Empty;
+
+        writer.WriteLine("---");
+        writer.WriteLine($"title: {title}");
+        writer.WriteLine("---");
+        writer.WriteLine("stateDiagram-v2");
+        writer.WriteLine($"    direction {GetDirectionToken(options.Direction)}");
+        writer.WriteLine();
+
+        foreach (var state in rendering.States)
+        {
+            writer.WriteLine($"    {state.Identifier}: {state.Descriptor.EncodeForMermaid(options)}");
+        }
+
+        if (rendering.States.Count > 0 && rendering.Transitions.Count > 0)
+        {
+            writer.WriteLine();
+        }
+
+        foreach (var transition in rendering.Transitions)
+        {
+            var descriptor = transition.Descriptor.EncodeForMermaid(options);
+            writer.Write($"    {transition.PreviousState} --> {transition.NextState} : {descriptor}");
+            WriteConditions(transition.Conditions, writer, options);
+            writer.WriteLine();
+        }
+    }
+
+    private static void WriteConditions(IReadOnlyList<string> conditions, TextWriter writer, MermaidOptions options)
+    {
+        if (conditions.Count == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < conditions.Count; i++)
+        {
+            var prefix = i == 0 ? "If" : "And";
+            writer.Write($" <br/> {prefix}: {conditions[i].EncodeForMermaid(options)}");
+        }
+    }
+
+    private static string GetDirectionToken(MermaidDirection direction)
+    {
+        return direction switch
+        {
+            MermaidDirection.TopToBottom => "TB",
+            MermaidDirection.LeftToRight => "LR",
+            _ => throw new ArgumentOutOfRangeException(nameof(direction), direction, "Unknown Mermaid direction."),
+        };
+    }
+}

--- a/src/ZCrew.StateCraft.Mermaid/StringExtensions.cs
+++ b/src/ZCrew.StateCraft.Mermaid/StringExtensions.cs
@@ -1,0 +1,105 @@
+using System.Text;
+
+namespace ZCrew.StateCraft.Mermaid;
+
+/// <summary>
+///     Mermaid-specific string extension members.
+/// </summary>
+internal static class StringExtensions
+{
+    extension(string text)
+    {
+        /// <summary>
+        ///     Encodes the string for safe inclusion in a Mermaid descriptor: characters that Mermaid would
+        ///     otherwise interpret (<c>#lt;</c>, <c>#gt;</c>, runs of spaces) are escaped, and newline characters
+        ///     are handled per <see cref="MermaidOptions.Newline"/>.
+        /// </summary>
+        /// <param name="options">The Mermaid options that control how newline characters are encoded.</param>
+        /// <returns>
+        ///     The encoded text, or the original string instance when no encoding was required.
+        /// </returns>
+        public string EncodeForMermaid(MermaidOptions options)
+        {
+            StringBuilder? builder = null;
+
+            var i = 0;
+            for (; i < text.Length; i++)
+            {
+                var c = text[i];
+                switch (c)
+                {
+                    case '<':
+                        ReplaceWithString("#lt;");
+                        break;
+
+                    case '>':
+                        ReplaceWithString("#gt;");
+                        break;
+
+                    // Preserve multiple spaces (which would otherwise be collapsed to a single space) by replacing
+                    // subsequent spaces with an HTML space
+                    case ' ' when PreviousCharacterIs(' '):
+                        ReplaceWithString("#nbsp;");
+                        break;
+
+                    // Skipping all newlines (\r, \n, or \r\n)
+                    case '\n' when PreviousCharacterIs('\r'):
+                    case '\r' or '\n' when options.Newline == MermaidNewline.Ignore:
+                        Skip();
+                        break;
+
+                    // Replace all newlines (\r or \n) with just a single space
+                    case '\r'
+                    or '\n' when options.Newline == MermaidNewline.Space:
+                        ReplaceWithChar(' ');
+                        break;
+
+                    // Replace all newlines (\r or \n) with an HTML single line break (br)
+                    case '\r'
+                    or '\n' when options.Newline == MermaidNewline.HtmlSingleLineBreak:
+                        ReplaceWithString("<br/>");
+                        break;
+
+                    // Append to the builder if it is initialized - otherwise the character is appended at that time
+                    default:
+                        builder?.Append(c);
+                        break;
+                }
+            }
+
+            return builder?.ToString() ?? text;
+
+            void Skip()
+            {
+                builder ??= new StringBuilder(text[..i]);
+            }
+
+            void ReplaceWithChar(char replacement)
+            {
+                if (builder == null)
+                {
+                    // Keep the same size since this is a char-for-char replacement
+                    builder = new StringBuilder(text[..i], text.Length);
+                }
+                builder.Append(replacement);
+            }
+
+            void ReplaceWithString(string replacement)
+            {
+                if (builder == null)
+                {
+                    // The most common replacement will be replacing a single '<' and '>' with "#lt;" and "#gt".
+                    // This is why we add 6 characters here so the builder doesn't have to be resized most of the time.
+                    // If the assumption is wrong the string builder can grow anyway
+                    builder = new StringBuilder(text[..i], text.Length + 6);
+                }
+                builder.Append(replacement);
+            }
+
+            bool PreviousCharacterIs(char c)
+            {
+                return i > 0 && text[i - 1] == c;
+            }
+        }
+    }
+}

--- a/src/ZCrew.StateCraft.Mermaid/ZCrew.StateCraft.Mermaid.csproj
+++ b/src/ZCrew.StateCraft.Mermaid/ZCrew.StateCraft.Mermaid.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- NuGet package metadata -->
+  <PropertyGroup>
+    <PackageTags>state-machine;mermaid</PackageTags>
+    <Description>Mermaid state machine diagram generator for ZCrew.StateCraft</Description>
+  </PropertyGroup>
+
+  <!-- NuGet package content -->
+  <ItemGroup>
+    <None Include="../../img/icon.png" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="/" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ZCrew.StateCraft/ZCrew.StateCraft.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ZCrew.StateCraft/Rendering/Contracts/IRenderableState.cs
+++ b/src/ZCrew.StateCraft/Rendering/Contracts/IRenderableState.cs
@@ -1,0 +1,13 @@
+namespace ZCrew.StateCraft.Rendering.Contracts;
+
+/// <summary>
+///     Represents a type that refers to a state and can render an identifier to uniquely identify the state.
+/// </summary>
+internal interface IRenderableState
+{
+    /// <summary>
+    ///     Return a unique identifier for a single state.
+    /// </summary>
+    /// <returns>The state identifier.</returns>
+    string RenderStateIdentifier();
+}

--- a/src/ZCrew.StateCraft/Rendering/Models/StateRenderingModel.cs
+++ b/src/ZCrew.StateCraft/Rendering/Models/StateRenderingModel.cs
@@ -41,7 +41,7 @@ internal sealed class StateRenderingModel<TState, TTransition>
     /// <summary>
     ///     The stable identifier used to reference this state from transitions. Built from the state value plus its type
     ///     parameters so that two parameterized states sharing the same underlying value but different parameter types
-    ///     produce distinct ids.
+    ///     produce distinct identifiers.
     /// </summary>
     public required string Identifier { get; init; }
 

--- a/src/ZCrew.StateCraft/Rendering/Models/TransitionRenderingModel.cs
+++ b/src/ZCrew.StateCraft/Rendering/Models/TransitionRenderingModel.cs
@@ -14,14 +14,33 @@ internal sealed class TransitionRenderingModel<TState, TTransition>
     /// <summary>
     ///     Initializes a new <see cref="TransitionRenderingModel{TState, TTransition}"/>.
     /// </summary>
+    /// <param name="previousState">The previous state.</param>
+    /// <param name="nextState">The next state.</param>
     /// <param name="descriptor">The display label for the transition.</param>
     /// <param name="conditions">The descriptors of the conditions that gate the transition.</param>
     [SetsRequiredMembers]
-    public TransitionRenderingModel(string descriptor, IReadOnlyList<string> conditions)
+    public TransitionRenderingModel(
+        string previousState,
+        string nextState,
+        string descriptor,
+        IReadOnlyList<string> conditions
+    )
     {
+        PreviousState = previousState;
+        NextState = nextState;
         Descriptor = descriptor;
         Conditions = conditions;
     }
+
+    /// <summary>
+    ///     The previous state that is being transitioned from.
+    /// </summary>
+    public required string PreviousState { get; init; }
+
+    /// <summary>
+    ///     The next state that is being transitioned to.
+    /// </summary>
+    public required string NextState { get; init; }
 
     /// <summary>
     ///     The display label for the transition — typically the <see cref="object.ToString"/> form of the trigger value.

--- a/src/ZCrew.StateCraft/Rendering/StateMachineRenderingContext.cs
+++ b/src/ZCrew.StateCraft/Rendering/StateMachineRenderingContext.cs
@@ -4,6 +4,31 @@ using ZCrew.StateCraft.Rendering.Models;
 namespace ZCrew.StateCraft.Rendering;
 
 /// <summary>
+///     Static helpers for constructing a populated
+///     <see cref="StateMachineRenderingContext{TState, TTransition}"/> from a configuration.
+/// </summary>
+internal static class StateMachineRenderingContext
+{
+    /// <summary>
+    ///     Walks <paramref name="stateMachineConfiguration"/> and returns a fully-populated rendering context.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state.</typeparam>
+    /// <typeparam name="TTransition">The type of the transition.</typeparam>
+    /// <param name="stateMachineConfiguration">The configuration to render.</param>
+    /// <returns>The populated context describing the state machine, its states, and its transitions.</returns>
+    public static StateMachineRenderingContext<TState, TTransition> Render<TState, TTransition>(
+        IStateMachineConfiguration<TState, TTransition> stateMachineConfiguration
+    )
+        where TState : notnull
+        where TTransition : notnull
+    {
+        var context = new StateMachineRenderingContext<TState, TTransition>();
+        context.AddToRenderingContext(stateMachineConfiguration);
+        return context;
+    }
+}
+
+/// <summary>
 ///     A mutable accumulator that <see cref="IRenderable{TState, TTransition}"/> implementations write into while a state
 ///     machine configuration tree is walked. Once populated, the collected models describe the full structure that a
 ///     renderer needs to produce a diagram.

--- a/src/ZCrew.StateCraft/States/Configuration/INextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/INextStateConfiguration.cs
@@ -14,7 +14,7 @@ namespace ZCrew.StateCraft.States.Configuration;
 ///     The transition type. This should be an <see langword="enum"/> type or it should be an equatable type so the
 ///     state machine behaves as expected.
 /// </typeparam>
-internal interface INextStateConfiguration<TState, TTransition> : IRenderableConditions
+internal interface INextStateConfiguration<TState, TTransition> : IRenderableConditions, IRenderableState
     where TState : notnull
     where TTransition : notnull
 {

--- a/src/ZCrew.StateCraft/States/Configuration/IPreviousStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/Configuration/IPreviousStateConfiguration.cs
@@ -14,7 +14,7 @@ namespace ZCrew.StateCraft.States.Configuration;
 ///     The transition type. This should be an <see langword="enum"/> type or it should be an equatable type so the
 ///     state machine behaves as expected.
 /// </typeparam>
-internal interface IPreviousStateConfiguration<TState, TTransition> : IRenderableConditions
+internal interface IPreviousStateConfiguration<TState, TTransition> : IRenderableConditions, IRenderableState
     where TState : notnull
     where TTransition : notnull
 {

--- a/src/ZCrew.StateCraft/States/NextStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/NextStateConfiguration.cs
@@ -1,4 +1,5 @@
 using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Rendering.Extensions;
 using ZCrew.StateCraft.States.Configuration;
 using ZCrew.StateCraft.States.Contracts;
 
@@ -58,6 +59,12 @@ internal class NextStateConfiguration<TState, TTransition> : INextStateConfigura
         }
 
         return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}";
     }
 
     /// <inheritdoc />
@@ -125,6 +132,12 @@ internal class NextStateConfiguration<TState, TTransition, T> : INextStateConfig
     }
 
     /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}_{typeof(T).RenderingIdentifier}";
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}<{typeof(T).FriendlyName}>";
@@ -188,6 +201,12 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2> : INextStateC
         }
 
         return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}_{typeof(T1).RenderingIdentifier}_{typeof(T2).RenderingIdentifier}";
     }
 
     /// <inheritdoc />
@@ -258,6 +277,15 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3> : INextSt
     }
 
     /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}"
+            + $"_{typeof(T1).RenderingIdentifier}"
+            + $"_{typeof(T2).RenderingIdentifier}"
+            + $"_{typeof(T3).RenderingIdentifier}";
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}<{typeof(T1).FriendlyName}, {typeof(T2).FriendlyName}, {typeof(T3).FriendlyName}>";
@@ -324,6 +352,16 @@ internal class NextStateConfiguration<TState, TTransition, T1, T2, T3, T4>
         }
 
         return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}"
+            + $"_{typeof(T1).RenderingIdentifier}"
+            + $"_{typeof(T2).RenderingIdentifier}"
+            + $"_{typeof(T3).RenderingIdentifier}"
+            + $"_{typeof(T4).RenderingIdentifier}";
     }
 
     /// <inheritdoc />

--- a/src/ZCrew.StateCraft/States/PreviousStateConfiguration.cs
+++ b/src/ZCrew.StateCraft/States/PreviousStateConfiguration.cs
@@ -1,4 +1,5 @@
 using ZCrew.StateCraft.Async;
+using ZCrew.StateCraft.Rendering.Extensions;
 using ZCrew.StateCraft.States.Configuration;
 using ZCrew.StateCraft.States.Contracts;
 
@@ -68,6 +69,12 @@ internal class PreviousStateConfiguration<TState, TTransition> : IPartialPreviou
         }
 
         return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}";
     }
 
     /// <inheritdoc />
@@ -147,6 +154,12 @@ internal class PreviousStateConfiguration<TState, TTransition, T>
     }
 
     /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}_{typeof(T).RenderingIdentifier}";
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}<{typeof(T).FriendlyName}>";
@@ -221,6 +234,12 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2>
         }
 
         return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}_{typeof(T1).RenderingIdentifier}_{typeof(T2).RenderingIdentifier}";
     }
 
     /// <inheritdoc />
@@ -302,6 +321,15 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3>
     }
 
     /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}"
+            + $"_{typeof(T1).RenderingIdentifier}"
+            + $"_{typeof(T2).RenderingIdentifier}"
+            + $"_{typeof(T3).RenderingIdentifier}";
+    }
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"{StateValue}<{typeof(T1).FriendlyName}, {typeof(T2).FriendlyName}, {typeof(T3).FriendlyName}>";
@@ -378,6 +406,16 @@ internal class PreviousStateConfiguration<TState, TTransition, T1, T2, T3, T4>
         }
 
         return this.conditions.Select(condition => condition.Descriptor).OfType<string>();
+    }
+
+    /// <inheritdoc />
+    public string RenderStateIdentifier()
+    {
+        return $"{StateValue}"
+            + $"_{typeof(T1).RenderingIdentifier}"
+            + $"_{typeof(T2).RenderingIdentifier}"
+            + $"_{typeof(T3).RenderingIdentifier}"
+            + $"_{typeof(T4).RenderingIdentifier}";
     }
 
     /// <inheritdoc />

--- a/src/ZCrew.StateCraft/Transitions/DirectTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/DirectTransitionConfiguration.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using ZCrew.StateCraft.Rendering;
 using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Extensions;
 using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.States.Configuration;
@@ -72,13 +74,20 @@ internal class DirectTransitionConfiguration<TState, TTransition>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var descriptor = $"{this.transitionValue}";
+        var previousState = this.previousStateConfiguration.RenderStateIdentifier();
+        var nextState = this.nextStateConfiguration.RenderStateIdentifier();
+        var descriptor = GetDescriptor();
         var conditions = new List<string>();
 
         conditions.AddRange(this.previousStateConfiguration.RenderConditions());
         conditions.AddRange(this.nextStateConfiguration.RenderConditions());
 
-        var transition = new TransitionRenderingModel<TState, TTransition>(descriptor, conditions);
+        var transition = new TransitionRenderingModel<TState, TTransition>(
+            previousState,
+            nextState,
+            descriptor,
+            conditions
+        );
         context.Transitions.Add(transition);
     }
 
@@ -94,5 +103,24 @@ internal class DirectTransitionConfiguration<TState, TTransition>
         }
 
         return $"{this.transitionValue}({this.previousStateConfiguration}) → {this.nextStateConfiguration}";
+    }
+
+    private string GetDescriptor()
+    {
+        if (this.nextStateConfiguration.TypeParameters.Count == 0)
+        {
+            return $"{this.transitionValue}";
+        }
+
+        var identifier = new StringBuilder($"{this.transitionValue}<");
+        for (var i = 0; i < this.nextStateConfiguration.TypeParameters.Count; i++)
+        {
+            if (i > 0)
+            {
+                identifier.Append(", ");
+            }
+            identifier.Append(this.nextStateConfiguration.TypeParameters[i].FriendlyName);
+        }
+        return identifier.Append('>').ToString();
     }
 }

--- a/src/ZCrew.StateCraft/Transitions/FromTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/FromTransitionConfiguration.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using ZCrew.StateCraft.Rendering;
 using ZCrew.StateCraft.Rendering.Contracts;
+using ZCrew.StateCraft.Rendering.Extensions;
 using ZCrew.StateCraft.Rendering.Models;
 using ZCrew.StateCraft.StateMachines.Contracts;
 using ZCrew.StateCraft.States;
@@ -143,7 +145,8 @@ internal class FromTransitionConfiguration<TState, TTransition>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
-        var descriptor = $"{this.transitionValue}";
+        var nextState = this.nextStateConfiguration.RenderStateIdentifier();
+        var descriptor = GetDescriptor();
         var conditions = this.nextStateConfiguration.RenderConditions().ToArray();
 
         // This requires all states to be loaded ahead of time. We can just add all states and then all transitions
@@ -157,7 +160,13 @@ internal class FromTransitionConfiguration<TState, TTransition>
                 continue;
             }
 
-            var transition = new TransitionRenderingModel<TState, TTransition>(descriptor, conditions);
+            var previousState = state.Identifier;
+            var transition = new TransitionRenderingModel<TState, TTransition>(
+                previousState,
+                nextState,
+                descriptor,
+                conditions
+            );
             context.Transitions.Add(transition);
         }
     }
@@ -166,6 +175,25 @@ internal class FromTransitionConfiguration<TState, TTransition>
     {
         this.excludedStates.Add(new ExcludedState(state, typeParameters));
         return this;
+    }
+
+    private string GetDescriptor()
+    {
+        if (this.nextStateConfiguration.TypeParameters.Count == 0)
+        {
+            return $"{this.transitionValue}";
+        }
+
+        var identifier = new StringBuilder($"{this.transitionValue}<");
+        for (var i = 0; i < this.nextStateConfiguration.TypeParameters.Count; i++)
+        {
+            if (i > 0)
+            {
+                identifier.Append(", ");
+            }
+            identifier.Append(this.nextStateConfiguration.TypeParameters[i].FriendlyName);
+        }
+        return identifier.Append('>').ToString();
     }
 
     private readonly record struct ExcludedState(TState State, Type[] TypeParameters)

--- a/src/ZCrew.StateCraft/Transitions/MappedTransitionConfiguration.cs
+++ b/src/ZCrew.StateCraft/Transitions/MappedTransitionConfiguration.cs
@@ -78,13 +78,20 @@ internal class MappedTransitionConfiguration<TState, TTransition>
     /// <inheritdoc />
     public void AddToRenderingContext(StateMachineRenderingContext<TState, TTransition> context)
     {
+        var previousState = this.previousStateConfiguration.RenderStateIdentifier();
+        var nextState = this.nextStateConfiguration.RenderStateIdentifier();
         var descriptor = $"{this.transitionValue}";
         var conditions = new List<string>();
 
         conditions.AddRange(this.previousStateConfiguration.RenderConditions());
         conditions.AddRange(this.nextStateConfiguration.RenderConditions());
 
-        var transition = new TransitionRenderingModel<TState, TTransition>(descriptor, conditions);
+        var transition = new TransitionRenderingModel<TState, TTransition>(
+            previousState,
+            nextState,
+            descriptor,
+            conditions
+        );
         context.Transitions.Add(transition);
     }
 

--- a/src/ZCrew.StateCraft/ZCrew.StateCraft.csproj
+++ b/src/ZCrew.StateCraft/ZCrew.StateCraft.csproj
@@ -21,4 +21,8 @@
       <DependentUpon>StateMachine.cs</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ZCrew.StateCraft.Mermaid" />
+  </ItemGroup>
 </Project>

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ConditionTests.cs
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ConditionTests.cs
@@ -1,0 +1,149 @@
+namespace ZCrew.StateCraft.Mermaid.IntegrationTests;
+
+public class ConditionTests
+{
+    private static bool IsAuthorized() => true;
+
+    private static bool HasCapacity() => true;
+
+    private static bool QueueIsHealthy() => true;
+
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionHasNoConditions_ShouldNotAppendIfClause()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state.WithTransition("Go", "Working"))
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle --> Working : Go", diagram);
+        Assert.DoesNotContain(" <br/> If:", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionHasOneCondition_ShouldAppendSingleIfClause()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state.WithTransition("Go", t => t.If(IsAuthorized).To("Working")))
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle --> Working : Go <br/> If: IsAuthorized", diagram);
+        Assert.DoesNotContain("And:", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionHasMultipleConditions_ShouldChainWithAndUsingHtmlBreaks()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState(
+                "Idle",
+                state =>
+                    state.WithTransition("Go", t => t.If(IsAuthorized).If(HasCapacity).If(QueueIsHealthy).To("Working"))
+            )
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains(
+            "    Idle --> Working : Go <br/> If: IsAuthorized <br/> And: HasCapacity <br/> And: QueueIsHealthy",
+            diagram
+        );
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenConditionHasCustomDescriptor_ShouldUseProvidedDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState(
+                "Idle",
+                state => state.WithTransition("Go", t => t.If(IsAuthorized, "user is authorized").To("Working"))
+            )
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle --> Working : Go <br/> If: user is authorized", diagram);
+        Assert.DoesNotContain("IsAuthorized", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenConditionIsLargerInlineExpression_ShouldRenderTheCapturedExpression()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState(
+                "Idle",
+                state =>
+                    state.WithTransition(
+                        "Go",
+                        t => t.If(() => IsAuthorized() && HasCapacity() && QueueIsHealthy()).To("Working")
+                    )
+            )
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("If: () =#gt; IsAuthorized() && HasCapacity() && QueueIsHealthy()", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenConditionIsLargerBlockBody_ShouldRenderTheCapturedBody()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState(
+                "Idle",
+                state =>
+                    state.WithTransition(
+                        "Go",
+                        t =>
+                            t.If(() =>
+                                {
+                                    var authorized = IsAuthorized();
+                                    var capacity = HasCapacity();
+                                    return authorized && capacity;
+                                })
+                                .To("Working")
+                    )
+            )
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("If:", diagram);
+        Assert.Contains("var authorized = IsAuthorized();", diagram);
+        Assert.Contains("var capacity = HasCapacity();", diagram);
+        Assert.Contains("return authorized && capacity;", diagram);
+    }
+}

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/DescriptorEncodingTests.cs
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/DescriptorEncodingTests.cs
@@ -1,0 +1,107 @@
+namespace ZCrew.StateCraft.Mermaid.IntegrationTests;
+
+public class DescriptorEncodingTests
+{
+    [Fact]
+    public void ToMermaidDiagram_WhenDescriptorContainsAngleBrackets_ShouldEscapeThemInDescriptorButNotInIdentifier()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Working", state => state.WithParameter<int>());
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Working_System.Int32: Working#lt;int#gt;", diagram);
+        Assert.DoesNotContain("Working_System.Int32: Working<int>", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenDescriptorContainsConsecutiveSpaces_ShouldReplaceSecondAndLaterSpacesWithNbsp()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Two  Spaces", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Two  Spaces: Two #nbsp;Spaces", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenNewlineOptionIsIgnore_ShouldStripNewlinesFromDescriptors()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Multi\nLine", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options => options.Newline = MermaidNewline.Ignore);
+
+        // Assert
+        Assert.Contains(": MultiLine", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenNewlineOptionIsSpace_ShouldReplaceNewlinesInDescriptorsWithSpace()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Multi\nLine", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options => options.Newline = MermaidNewline.Space);
+
+        // Assert
+        Assert.Contains(": Multi Line", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenNewlineOptionIsHtmlSingleLineBreak_ShouldReplaceNewlinesInDescriptorsWithBrTag()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Multi\nLine", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options => options.Newline = MermaidNewline.HtmlSingleLineBreak);
+
+        // Assert
+        Assert.Contains(": Multi<br/>Line", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenStateNameContainsAngleBrackets_ShouldLeaveIdentifierRawAndEncodeOnlyDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("<weird>", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    <weird>: #lt;weird#gt;", diagram);
+    }
+}

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/DiagramHeaderTests.cs
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/DiagramHeaderTests.cs
@@ -1,0 +1,64 @@
+namespace ZCrew.StateCraft.Mermaid.IntegrationTests;
+
+public class DiagramHeaderTests
+{
+    [Fact]
+    public void ToMermaidDiagram_WhenCalled_ShouldEmitTitleAndStateDiagramHeader()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        var expected = """
+            ---
+            title: State Machine
+            ---
+            stateDiagram-v2
+                direction TB
+
+                Idle: Idle
+
+            """;
+        Assert.Equal(expected.ReplaceLineEndings(), diagram.ReplaceLineEndings());
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenDirectionIsTopToBottom_ShouldEmitDirectionTB()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options => options.Direction = MermaidDirection.TopToBottom);
+
+        // Assert
+        Assert.Contains("    direction TB", diagram);
+        Assert.DoesNotContain("    direction LR", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenDirectionIsLeftToRight_ShouldEmitDirectionLR()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options => options.Direction = MermaidDirection.LeftToRight);
+
+        // Assert
+        Assert.Contains("    direction LR", diagram);
+        Assert.DoesNotContain("    direction TB", diagram);
+    }
+}

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/StateTests.cs
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/StateTests.cs
@@ -1,0 +1,84 @@
+namespace ZCrew.StateCraft.Mermaid.IntegrationTests;
+
+public class StateTests
+{
+    [Fact]
+    public void ToMermaidDiagram_WhenStateIsParameterless_ShouldRenderIdentifierMatchingDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle: Idle", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenStateHasSingleTypeParameter_ShouldSuffixIdentifierAndDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Working", state => state.WithParameter<int>());
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Working_System.Int32: Working#lt;int#gt;", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenStateHasMultipleTypeParameters_ShouldIncludeEachParameterInIdentifierAndDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Storing", state => state.WithParameters<int, string>());
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Storing_System.Int32_System.String: Storing#lt;int, string#gt;", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenMultipleStatesAreRegistered_ShouldEmitEachOnItsOwnLineInDeclarationOrder()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state)
+            .WithState("Working", state => state)
+            .WithState("Finished", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        var expected = """
+            ---
+            title: State Machine
+            ---
+            stateDiagram-v2
+                direction TB
+
+                Idle: Idle
+                Working: Working
+                Finished: Finished
+
+            """;
+        Assert.Equal(expected.ReplaceLineEndings(), diagram.ReplaceLineEndings());
+    }
+}

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ToMermaidDiagramApiTests.cs
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ToMermaidDiagramApiTests.cs
@@ -1,0 +1,88 @@
+namespace ZCrew.StateCraft.Mermaid.IntegrationTests;
+
+public class ToMermaidDiagramApiTests
+{
+    [Fact]
+    public void ToMermaidDiagram_WhenOptionsInstanceIsProvided_ShouldHonorSuppliedDirection()
+    {
+        // Arrange
+        var configuration = NewConfiguration();
+        var options = new MermaidOptions { Direction = MermaidDirection.LeftToRight };
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options);
+
+        // Assert
+        Assert.Contains("    direction LR", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenOptionsInstanceIsNull_ShouldFallBackToDefaults()
+    {
+        // Arrange
+        var configuration = NewConfiguration();
+
+        // Act
+        var defaultDiagram = configuration.ToMermaidDiagram();
+        var nullDiagram = configuration.ToMermaidDiagram((MermaidOptions?)null);
+
+        // Assert
+        Assert.Equal(defaultDiagram, nullDiagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenConfigureCallbackIsProvided_ShouldApplyMutationsToFreshOptions()
+    {
+        // Arrange
+        var configuration = NewConfiguration();
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram(options => options.Direction = MermaidDirection.LeftToRight);
+
+        // Assert
+        Assert.Contains("    direction LR", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenConfigureCallbackIsNull_ShouldFallBackToDefaults()
+    {
+        // Arrange
+        var configuration = NewConfiguration();
+
+        // Act
+        var defaultDiagram = configuration.ToMermaidDiagram();
+        var nullDiagram = configuration.ToMermaidDiagram((Action<MermaidOptions>?)null);
+
+        // Assert
+        Assert.Equal(defaultDiagram, nullDiagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenInstanceAndCallbackOverloadsExpressSameOptions_ShouldProduceIdenticalOutput()
+    {
+        // Arrange
+        var configuration = NewConfiguration();
+
+        // Act
+        var fromInstance = configuration.ToMermaidDiagram(
+            new MermaidOptions
+            {
+                Direction = MermaidDirection.LeftToRight,
+                Newline = MermaidNewline.HtmlSingleLineBreak,
+            }
+        );
+        var fromCallback = configuration.ToMermaidDiagram(options =>
+        {
+            options.Direction = MermaidDirection.LeftToRight;
+            options.Newline = MermaidNewline.HtmlSingleLineBreak;
+        });
+
+        // Assert
+        Assert.Equal(fromInstance, fromCallback);
+    }
+
+    private static IStateMachineConfiguration<string, string> NewConfiguration()
+    {
+        return StateMachine.Configure<string, string>().WithInitialState("Idle").WithState("Idle", state => state);
+    }
+}

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/TransitionTests.cs
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/TransitionTests.cs
@@ -1,0 +1,124 @@
+namespace ZCrew.StateCraft.Mermaid.IntegrationTests;
+
+public class TransitionTests
+{
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionIsParameterless_ShouldRenderArrowWithTriggerAsDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state.WithTransition("Start", "Working"))
+            .WithState("Working", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle --> Working : Start", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionTargetsParameterizedState_ShouldIncludeTypeParameterInDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state.WithTransition("Start", t => t.WithParameter<int>().To("Working")))
+            .WithState("Working", state => state.WithParameter<int>());
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle --> Working_System.Int32 : Start#lt;int#gt;", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionIsMapped_ShouldUseTriggerAloneAsDescriptor()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle", 1)
+            .WithState(
+                "Idle",
+                state =>
+                    state
+                        .WithParameter<int>()
+                        .WithTransition(
+                            "Start",
+                            t => t.WithMappedParameter<string>(value => value.ToString()).To("Working")
+                        )
+            )
+            .WithState("Working", state => state.WithParameter<string>());
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Idle_System.Int32 --> Working_System.String : Start", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenTransitionIsReentrant_ShouldRenderArrowToSameStateIdentifier()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Working", 1)
+            .WithState(
+                "Working",
+                state => state.WithParameter<int>().WithTransition("Start", t => t.WithSameParameter().To("Working"))
+            );
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        Assert.Contains("    Working_System.Int32 --> Working_System.Int32 : Start", diagram);
+    }
+
+    [Fact]
+    public void ToMermaidDiagram_WhenStateMachineHasMultipleTransitions_ShouldEmitAllTransitionsInDeclarationOrder()
+    {
+        // Arrange
+        var configuration = StateMachine
+            .Configure<string, string>()
+            .WithInitialState("Idle")
+            .WithState("Idle", state => state.WithTransition("Start", "Working").WithTransition("Stop", "Finished"))
+            .WithState(
+                "Working",
+                state => state.WithTransition("Suspend", "Suspended").WithTransition("Stop", "Finished")
+            )
+            .WithState("Suspended", state => state.WithTransition("Resume", "Working"))
+            .WithState("Finished", state => state);
+
+        // Act
+        var diagram = configuration.ToMermaidDiagram();
+
+        // Assert
+        var expected = """
+            ---
+            title: State Machine
+            ---
+            stateDiagram-v2
+                direction TB
+
+                Idle: Idle
+                Working: Working
+                Suspended: Suspended
+                Finished: Finished
+
+                Idle --> Working : Start
+                Idle --> Finished : Stop
+                Working --> Suspended : Suspend
+                Working --> Finished : Stop
+                Suspended --> Working : Resume
+
+            """;
+        Assert.Equal(expected.ReplaceLineEndings(), diagram.ReplaceLineEndings());
+    }
+}

--- a/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ZCrew.StateCraft.Mermaid.IntegrationTests.csproj
+++ b/tests/ZCrew.StateCraft.Mermaid.IntegrationTests/ZCrew.StateCraft.Mermaid.IntegrationTests.csproj
@@ -1,0 +1,5 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../../src/ZCrew.StateCraft.Mermaid/ZCrew.StateCraft.Mermaid.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adds in the ability to export state machines as mermaid diagrams.

For example:

```csharp
var configuration = StateMachine
    .Configure<State, Transition>()
    .WithInitialState(State.Idle)
    .WithState(State.Idle, state => state
        .WithTransition(Transition.Start, t => t
            .If(QueueIsHealthy)
            .To(State.Running)))
    .WithState(State.Running, state => state
        .WithTransition(Transition.Complete, State.Finished))
    .WithState(State.Finished, state => state);

var diagram = configuration.ToMermaidDiagram();
```

Will emit:

```
---
title: State Machine
---
stateDiagram-v2
    direction TB

    Idle: Idle
    Running: Running
    Finished: Finished

    Idle --> Running : Start <br/> If: QueueIsHealthy
    Running --> Finished : Complete
```

Which renders as:

```mermaid
---
title: State Machine
---
stateDiagram-v2
    direction TB

    Idle: Idle
    Running: Running
    Finished: Finished

    Idle --> Running : Start <br/> If: QueueIsHealthy
    Running --> Finished : Complete
```

Closes #161