### PR TITLE
#137 - Add initial state validation

### DIFF
--- a/src/ZCrew.StateCraft/Validation/StaticInitialStateValidator.cs
+++ b/src/ZCrew.StateCraft/Validation/StaticInitialStateValidator.cs
@@ -1,0 +1,71 @@
+using ZCrew.StateCraft.Identities;
+
+namespace ZCrew.StateCraft.Validation;
+
+internal static class StaticInitialStateValidator
+{
+    /// <summary>
+    ///     Validates that the initial state, when provided statically from
+    ///     <see cref="IStateMachineConfiguration{TState,TTransition}.WithInitialState(TState)"/> (and overloads),
+    ///     exists.
+    /// </summary>
+    /// <param name="context">The validation context.</param>
+    /// <typeparam name="TState">The state type.</typeparam>
+    /// <typeparam name="TTransition">The transition type.</typeparam>
+    public static void Validate<TState, TTransition>(StateMachineValidationContext<TState, TTransition> context)
+        where TState : notnull
+        where TTransition : notnull
+    {
+        if (context.Info.InitialState is IStaticInitialStateInfo<TState, TTransition> staticInitialState)
+        {
+            var initialState = StateIdentity.For(
+                staticInitialState.InitialStateValue,
+                staticInitialState.InitialParameterTypes
+            );
+            if (!context.Info.States.Contains(initialState, StateIdentityEqualityComparer<TState>.Instance))
+            {
+                // Check if there's a state with the right value but wrong parameter arity
+                var matchByValueOnly = context
+                    .Info.States.Where(s =>
+                        EqualityComparer<TState>.Default.Equals(s.StateValue, initialState.StateValue)
+                    )
+                    .ToList();
+
+                if (matchByValueOnly.Count == 1)
+                {
+                    var correctedInitialStateCall = GetCorrectedInitialStateCall(matchByValueOnly[0]);
+                    context.ValidationErrors.Add(
+                        $"Initial state: {initialState} was not found, "
+                            + $"but a state was registered as {matchByValueOnly[0]}. "
+                            + $"Specify the correct parameters like: {correctedInitialStateCall}"
+                    );
+                }
+                else if (matchByValueOnly.Count > 1)
+                {
+                    var stateList = string.Join(", ", matchByValueOnly);
+                    context.ValidationErrors.Add(
+                        $"Initial state: {initialState} was not found, "
+                            + $"but states with the same value were registered: {stateList}. "
+                            + "Specify the correct parameters for the state you'd like to use as the initial state"
+                    );
+                }
+                else
+                {
+                    context.ValidationErrors.Add($"Initial state: {initialState} was not found");
+                }
+            }
+        }
+    }
+
+    private static string GetCorrectedInitialStateCall<TState>(IStateIdentity<TState> registeredState)
+        where TState : notnull
+    {
+        if (registeredState.StateParameterTypes.Count == 0)
+        {
+            return $"WithInitialState({typeof(TState).Name}.{registeredState.StateValue})";
+        }
+
+        var typeParameters = string.Join(", ", registeredState.StateParameterTypes.Select(type => type.FriendlyName));
+        return $"WithInitialState<{typeParameters}>({typeof(TState).Name}.{registeredState.StateValue}, ...)";
+    }
+}

--- a/tests/ZCrew.StateCraft.UnitTests/Validation/StaticInitialStateValidatorTests.cs
+++ b/tests/ZCrew.StateCraft.UnitTests/Validation/StaticInitialStateValidatorTests.cs
@@ -1,0 +1,202 @@
+using ZCrew.StateCraft.Info;
+using ZCrew.StateCraft.Validation;
+
+namespace ZCrew.StateCraft.UnitTests.Validation;
+
+public class StaticInitialStateValidatorTests
+{
+    [Fact]
+    public void Validate_WhenInitialStateIsNull_ShouldPass()
+    {
+        // Arrange
+        var info = new StateMachineInfo<string, string>(null);
+        info.Add(new StateInfo<string, string>(info, "A", []));
+        info.Add(new StateInfo<string, string>(info, "B", []));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        Assert.Empty(context.ValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_WhenInitialStateIsDynamic_ShouldPass()
+    {
+        // Arrange
+        var initialState = new DynamicInitialStateInfo<string, string>("provider", []);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", []));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        Assert.Empty(context.ValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_WhenParameterlessInitialStateExists_ShouldPass()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [], []);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", []));
+        info.Add(new StateInfo<string, string>(info, "B", []));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        Assert.Empty(context.ValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_WhenParameterizedInitialStateExists_ShouldPass()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [42], [typeof(int)]);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(int)]));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        Assert.Empty(context.ValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_WhenMultiParameterInitialStateExists_ShouldPass()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>(
+            "A",
+            [42, "value"],
+            [typeof(int), typeof(string)]
+        );
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(int), typeof(string)]));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        Assert.Empty(context.ValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_WhenInitialStateExistsAlongsideSameValueDifferentArity_ShouldPass()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [42], [typeof(int)]);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(int)]));
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(string)]));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        Assert.Empty(context.ValidationErrors);
+    }
+
+    [Fact]
+    public void Validate_WhenInitialStateNotFound_ShouldFail()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [], []);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "B", []));
+        info.Add(new StateInfo<string, string>(info, "C", []));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        var error = Assert.Single(context.ValidationErrors);
+        Assert.Contains("Initial state: A was not found", error);
+        Assert.DoesNotContain("Specify", error);
+    }
+
+    [Fact]
+    public void Validate_WhenNoStatesRegistered_ShouldFail()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [], []);
+        var info = new StateMachineInfo<string, string>(initialState);
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        var error = Assert.Single(context.ValidationErrors);
+        Assert.Contains("Initial state: A was not found", error);
+    }
+
+    [Fact]
+    public void Validate_WhenWrongArityWithParameterizedRegistered_ShouldSuggestCorrection()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [], []);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(int)]));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        var error = Assert.Single(context.ValidationErrors);
+        Assert.Contains("was not found", error);
+        Assert.Contains("Specify the correct parameters like:", error);
+        Assert.Contains("WithInitialState<int>(String.A, ...)", error);
+    }
+
+    [Fact]
+    public void Validate_WhenWrongArityWithParameterlessRegistered_ShouldSuggestCorrection()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [42], [typeof(int)]);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", []));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        var error = Assert.Single(context.ValidationErrors);
+        Assert.Contains("was not found", error);
+        Assert.Contains("Specify the correct parameters like:", error);
+        Assert.Contains("WithInitialState(String.A)", error);
+    }
+
+    [Fact]
+    public void Validate_WhenMatchesMultipleStatesByValue_ShouldFail()
+    {
+        // Arrange
+        var initialState = new StaticInitialStateInfo<string, string>("A", [], []);
+        var info = new StateMachineInfo<string, string>(initialState);
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(int)]));
+        info.Add(new StateInfo<string, string>(info, "A", [typeof(string)]));
+        var context = new StateMachineValidationContext<string, string> { Info = info };
+
+        // Act
+        StaticInitialStateValidator.Validate(context);
+
+        // Assert
+        var error = Assert.Single(context.ValidationErrors);
+        Assert.Contains("states with the same value were registered", error);
+        Assert.Contains("A<int>, A<string>", error);
+        Assert.Contains("you'd like to use as the initial state", error);
+    }
+}


### PR DESCRIPTION
Adds initial state validation to verify that the statically provided initial state (e.g `WithInitialState(State.Starting)`) actually exists

Closes #137